### PR TITLE
fix: correct Liquibase changeset order (data insert before status mig…

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-1.0.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.0.xml
@@ -475,6 +475,14 @@
         <addPrimaryKey tableName="employeegroupclient" columnNames="employeegroupid,clientid" constraintName="pk_employeegroupclient"/>
     </changeSet>
 
+    <changeSet id="1.0.0-drop-insert" author="mouha">
+        <sqlFile path="../data/insert-data.sql"
+                 relativeToChangelogFile="true"
+                 splitStatements="true"
+                 stripComments="true"
+                 encoding="UTF-8"/>
+    </changeSet>
+
     <changeSet id="1.0.0-migrate-status-to-active" author="mouhamed">
 
         <addColumn tableName="client">
@@ -533,13 +541,5 @@
         <addNotNullConstraint tableName="subvention" columnName="active" columnDataType="BOOLEAN"/>
         <dropColumn tableName="subvention" columnName="status"/>
 
-    </changeSet>
-
-    <changeSet id="1.0.0-drop-insert" author="mouha">
-        <sqlFile path="../data/insert-data.sql"
-                 relativeToChangelogFile="true"
-                 splitStatements="true"
-                 stripComments="true"
-                 encoding="UTF-8"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
…ration)

Le changeset 1.0.0-drop-insert (insert-data.sql) doit s'exécuter avant 1.0.0-migrate-status-to-active pour que les INSERT avec la colonne status réussissent avant que la colonne soit supprimée. L'ordre précédent cassait toute installation fraîche de la base de données.