### PR TITLE
feat: generate ref on create + init JPA_SEQUENCE

### DIFF
--- a/src/main/java/com/sn/onepay/services/impl/EmployeeGroupServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/EmployeeGroupServiceImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -33,6 +34,7 @@ public class EmployeeGroupServiceImpl implements EmployeeGroupService {
     public EmployeeGroupDTO createEmployeeGroup(EmployeeGroupDTO employeeGroupDTO) {
 
         EmployeeGroup group = employeeGroupMapper.asEntity(employeeGroupDTO);
+        group.setRef(UUID.randomUUID().toString());
         group.setActive(true);
         var savedGroup = employeeGroupRepository.save(group);
 

--- a/src/main/java/com/sn/onepay/services/impl/SubventionServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/SubventionServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -42,6 +43,7 @@ public class SubventionServiceImpl implements SubventionService {
         }
 
         Subvention subvention = subventionMapper.asEntity(subventionDTO);
+        subvention.setRef(UUID.randomUUID().toString());
         subvention.setActive(true);
         var savedSubvention = subventionRepository.save(subvention);
 

--- a/src/main/resources/db/changelog/db.changelog-1.0.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.0.xml
@@ -475,6 +475,17 @@
         <addPrimaryKey tableName="employeegroupclient" columnNames="employeegroupid,clientid" constraintName="pk_employeegroupclient"/>
     </changeSet>
 
+    <changeSet id="1.0.0-init-jpa-sequence-employeegroup-subvention" author="mouhamed">
+        <insert tableName="jpa_sequence">
+            <column name="seq_key" value="EmployeeGroupId"/>
+            <column name="seq_value" valueNumeric="1"/>
+        </insert>
+        <insert tableName="jpa_sequence">
+            <column name="seq_key" value="SubventionId"/>
+            <column name="seq_value" valueNumeric="1"/>
+        </insert>
+    </changeSet>
+
     <changeSet id="1.0.0-drop-insert" author="mouha">
         <sqlFile path="../data/insert-data.sql"
                  relativeToChangelogFile="true"

--- a/src/test/java/com/sn/onepay/services/impl/EmployeeGroupServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/EmployeeGroupServiceImplTest.java
@@ -50,6 +50,7 @@ class EmployeeGroupServiceImplTest {
 
         assertThat(result).isEqualTo(resultDTO);
         assertThat(entity.isActive()).isTrue();
+        assertThat(entity.getRef()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/sn/onepay/services/impl/SubventionServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/SubventionServiceImplTest.java
@@ -95,6 +95,7 @@ class SubventionServiceImplTest {
 
         assertThat(result).isEqualTo(resultDTO);
         assertThat(entity.isActive()).isTrue();
+        assertThat(entity.getRef()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
feat: generate ref on create + init JPA_SEQUENCE for EmployeeGroup and Subvention

- EmployeeGroupServiceImpl et SubventionServiceImpl génèrent désormais un UUID aléatoire comme ref à la création (setRef before save)
- Nouveau changeset Liquibase 1.0.0-init-jpa-sequence-employeegroup-subvention pour initialiser les entrées EmployeeGroupId et SubventionId dans JPA_SEQUENCE
- Tests mis à jour : assertion assertThat(entity.getRef()).isNotNull() sur create