### PR TITLE
feat: add used flag to client QR code with consumption on payment

### DIFF
--- a/src/main/java/com/sn/onepay/dto/PaymentDTO.java
+++ b/src/main/java/com/sn/onepay/dto/PaymentDTO.java
@@ -33,6 +33,9 @@ public record PaymentDTO(
         @NotNull(message = "Payment module can not be null")
         Modules module,
 
+        @Schema(name = "qrCodeRef", description = "Reference of the client QR code consumed by this payment (mode: cashier scans client)")
+        String qrCodeRef,
+
         @Schema(name = "paymentDate", description = "Date of the payment made")
         LocalDateTime paymentDate,
 

--- a/src/main/java/com/sn/onepay/dto/QRCodeClientDTO.java
+++ b/src/main/java/com/sn/onepay/dto/QRCodeClientDTO.java
@@ -1,7 +1,9 @@
 package com.sn.onepay.dto;
 
 public record QRCodeClientDTO(
+        String ref,
         Long clientId,
+        Boolean used,
         Double maxAmountRestauration,
         Double maxAmountGasStation,
         Double maxAmountTelephony,

--- a/src/main/java/com/sn/onepay/entity/QRCodeClient.java
+++ b/src/main/java/com/sn/onepay/entity/QRCodeClient.java
@@ -1,0 +1,58 @@
+package com.sn.onepay.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.TableGenerator;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@EqualsAndHashCode(exclude = "client")
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "QRCodeClient")
+@TableGenerator(name = "QRCodeClientGen", table = "JPA_SEQUENCE", pkColumnName = "SEQ_KEY", valueColumnName = "SEQ_VALUE", pkColumnValue = "QRCodeClientId", allocationSize = 1)
+public class QRCodeClient {
+
+    @Id
+    @Column(name = "QRCodeClientId", unique = true, nullable = false)
+    @GeneratedValue(strategy = GenerationType.TABLE, generator = "QRCodeClientGen")
+    Long id;
+
+    @Column(name = "Ref", unique = true, nullable = false)
+    String ref;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ClientId", nullable = false)
+    Client client;
+
+    @Column(name = "Used", nullable = false)
+    boolean used;
+
+    @Column(name = "Active", nullable = false)
+    boolean active;
+
+    @CreatedDate
+    @Column(name = "CreationDate", updatable = false)
+    LocalDateTime creationDate;
+
+    @LastModifiedDate
+    @Column(name = "ModificationDate", insertable = false)
+    LocalDateTime modificationDate;
+}

--- a/src/main/java/com/sn/onepay/repository/QRCodeClientRepository.java
+++ b/src/main/java/com/sn/onepay/repository/QRCodeClientRepository.java
@@ -1,0 +1,13 @@
+package com.sn.onepay.repository;
+
+import com.sn.onepay.entity.QRCodeClient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QRCodeClientRepository extends JpaRepository<QRCodeClient, Long>, QuerydslPredicateExecutor<QRCodeClient> {
+    Optional<QRCodeClient> findByRef(String ref);
+}

--- a/src/main/java/com/sn/onepay/services/QRCodeService.java
+++ b/src/main/java/com/sn/onepay/services/QRCodeService.java
@@ -6,4 +6,5 @@ import com.sn.onepay.dto.QRCodeClientDTO;
 public interface QRCodeService {
     QRCodeCashierDTO getCashierQrCode(Long cashierId);
     QRCodeClientDTO getClientQrCode(Long clientId);
+    void consumeClientQrCode(String qrCodeRef, Long clientId);
 }

--- a/src/main/java/com/sn/onepay/services/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/PaymentServiceImpl.java
@@ -15,6 +15,7 @@ import com.sn.onepay.repository.PaymentRepository;
 import com.sn.onepay.services.EnterpriseConfigurationService;
 import com.sn.onepay.services.PartnershipService;
 import com.sn.onepay.services.PaymentService;
+import com.sn.onepay.services.QRCodeService;
 import com.sn.onepay.services.SalesConfigurationsService;
 import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
@@ -40,6 +41,7 @@ public class PaymentServiceImpl implements PaymentService {
     final EnterpriseConfigurationService enterpriseConfigurationService;
     final SalesConfigurationsService salesConfigurationsService;
     final PartnershipService partnershipService;
+    final QRCodeService qrCodeService;
 
     @Override
     public PaymentDTO createPayment(PaymentDTO paymentDTO) {
@@ -60,6 +62,10 @@ public class PaymentServiceImpl implements PaymentService {
             throw new ObjectValidationException("Paiement non autorisé");
 
         if(Boolean.TRUE.equals(partnership.active()) && (salesConfigurations.maxAmount() >= paymentDTO.amount() && salesConfigurations.minAmount() <= paymentDTO.amount())) {
+            /*Consume the client QR code if the payment comes from a cashier scan (mode B)*/
+            if (Objects.nonNull(paymentDTO.qrCodeRef()))
+                qrCodeService.consumeClientQrCode(paymentDTO.qrCodeRef(), clientId);
+
             switch (module) {
                 case RESTAURATION -> {
                     if (paymentDTO.amount() + getSumOfAllPaymentsByClientIdAndModule(clientId, module) > enterpriseConfiguration.maxAmountRestauration()) {

--- a/src/main/java/com/sn/onepay/services/impl/QRCodeServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/QRCodeServiceImpl.java
@@ -2,10 +2,13 @@ package com.sn.onepay.services.impl;
 
 import com.sn.onepay.dto.QRCodeCashierDTO;
 import com.sn.onepay.dto.QRCodeClientDTO;
+import com.sn.onepay.entity.QRCodeClient;
+import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.repository.CashierRepository;
 import com.sn.onepay.repository.ClientRepository;
 import com.sn.onepay.repository.EnterpriseConfigurationRepository;
+import com.sn.onepay.repository.QRCodeClientRepository;
 import com.sn.onepay.repository.SalesConfigurationsRepository;
 import com.sn.onepay.services.QRCodeService;
 import jakarta.transaction.Transactional;
@@ -16,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -28,6 +32,7 @@ public class QRCodeServiceImpl implements QRCodeService {
     final SalesConfigurationsRepository salesConfigurationsRepository;
     final ClientRepository clientRepository;
     final EnterpriseConfigurationRepository enterpriseConfigurationRepository;
+    final QRCodeClientRepository qrCodeClientRepository;
 
     @Override
     public QRCodeCashierDTO getCashierQrCode(Long cashierId) {
@@ -47,6 +52,33 @@ public class QRCodeServiceImpl implements QRCodeService {
         if(Objects.isNull(configuration))
             throw new ResourceNotFoundException("Configuration", "configId", null);
 
-        return new QRCodeClientDTO(clientId, configuration.getMaxAmountRestauration(), configuration.getMaxAmountGasStation(), configuration.getMaxAmountTelephony(), configuration.getMaxAmountMarket());
+        var qrCode = new QRCodeClient();
+        qrCode.setRef(UUID.randomUUID().toString());
+        qrCode.setClient(client);
+        qrCode.setUsed(false);
+        qrCode.setActive(true);
+        qrCode = qrCodeClientRepository.save(qrCode);
+
+        log.info("QRCode client saved: {}", qrCode);
+        log.trace("QRCode client saved with id: {}", qrCode.getId());
+
+        return new QRCodeClientDTO(qrCode.getRef(), clientId, qrCode.isUsed(), configuration.getMaxAmountRestauration(), configuration.getMaxAmountGasStation(), configuration.getMaxAmountTelephony(), configuration.getMaxAmountMarket());
+    }
+
+    @Override
+    public void consumeClientQrCode(String qrCodeRef, Long clientId) {
+        var qrCode = qrCodeClientRepository.findByRef(qrCodeRef).orElseThrow(() -> new ResourceNotFoundException("QRCode client", "ref", qrCodeRef));
+
+        if (!qrCode.isActive() || !qrCode.getClient().getId().equals(clientId))
+            throw new ObjectValidationException("QR code invalide");
+
+        if (qrCode.isUsed())
+            throw new ObjectValidationException("QR code déjà utilisé");
+
+        qrCode.setUsed(true);
+        qrCodeClientRepository.saveAndFlush(qrCode);
+
+        log.info("QRCode client consumed: {}", qrCodeRef);
+        log.trace("QRCode client consumed with id: {}", qrCode.getId());
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-1.0.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.0.xml
@@ -553,4 +553,38 @@
         <dropColumn tableName="subvention" columnName="status"/>
 
     </changeSet>
+
+    <changeSet id="1.0.0-add-qrcode-client" author="mouhamed">
+
+        <createTable tableName="qrcodeclient">
+            <column name="qrcodeclientid" type="numeric(20)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="ref" type="varchar(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+
+            <column name="clientid" type="numeric(20)">
+                <constraints nullable="false" foreignKeyName="fk_qrcodeclient_client" references="client(clientid)"/>
+            </column>
+
+            <column name="used" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="creationdate" type="TIMESTAMP(6) WITHOUT TIMEZONE"/>
+            <column name="modificationdate" type="TIMESTAMP(6) WITHOUT TIMEZONE"/>
+        </createTable>
+
+        <insert tableName="jpa_sequence">
+            <column name="seq_key" value="QRCodeClientId"/>
+            <column name="seq_value" valueNumeric="1"/>
+        </insert>
+
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/com/sn/onepay/controller/QRCodeControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/QRCodeControllerTest.java
@@ -26,7 +26,7 @@ class QRCodeControllerTest extends BaseControllerTest {
     @Test
     void getClientQRCode_returns200() throws Exception {
         when(qrCodeService.getClientQrCode(anyLong()))
-                .thenReturn(new QRCodeClientDTO(1L, 500.0, 200.0, 100.0, 300.0));
+                .thenReturn(new QRCodeClientDTO("qr-ref", 1L, false, 500.0, 200.0, 100.0, 300.0));
 
         mockMvc.perform(get("/v1/onepay/qrcode/client").param("clientId", "1"))
                 .andExpect(status().isOk());

--- a/src/test/java/com/sn/onepay/services/impl/PaymentServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/PaymentServiceImplTest.java
@@ -16,6 +16,7 @@ import com.sn.onepay.mapper.PaymentMapper;
 import com.sn.onepay.repository.PaymentRepository;
 import com.sn.onepay.services.EnterpriseConfigurationService;
 import com.sn.onepay.services.PartnershipService;
+import com.sn.onepay.services.QRCodeService;
 import com.sn.onepay.services.SalesConfigurationsService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,6 +56,9 @@ class PaymentServiceImplTest {
 
     @Mock
     PartnershipService partnershipService;
+
+    @Mock
+    QRCodeService qrCodeService;
 
     @InjectMocks
     PaymentServiceImpl paymentService;
@@ -138,6 +142,21 @@ class PaymentServiceImplTest {
     @Test
     void createPayment_throwsWhenAmountBelowMin() {
         var dto = buildPaymentDTO(Modules.RESTAURATION, 5.0);
+        var salesConfig = buildSalesConfig(10.0, 100.0);
+        var enterpriseConfig = buildEnterpriseConfig(500.0, 500.0, 500.0, 500.0);
+        var activePartnership = buildActivePartnership();
+        when(salesConfigurationsService.getSalesConfigurationsBySalesId(1L)).thenReturn(salesConfig);
+        when(enterpriseConfigurationService.getEnterpriseConfigurationByEnterpriseId(2L)).thenReturn(enterpriseConfig);
+        when(partnershipService.getPartnershipsBySalesIdAndEnterpriseId(1L, 2L)).thenReturn(activePartnership);
+
+        assertThatThrownBy(() -> paymentService.createPayment(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("non autorisé");
+    }
+
+    @Test
+    void createPayment_throwsWhenAmountAboveMax() {
+        var dto = buildPaymentDTO(Modules.RESTAURATION, 150.0);
         var salesConfig = buildSalesConfig(10.0, 100.0);
         var enterpriseConfig = buildEnterpriseConfig(500.0, 500.0, 500.0, 500.0);
         var activePartnership = buildActivePartnership();
@@ -307,6 +326,55 @@ class PaymentServiceImplTest {
     }
 
     @Test
+    void createPayment_withQrCodeRef_consumesQrCode() {
+        var dto = buildPaymentDTO(Modules.RESTAURATION, 50.0);
+        when(dto.qrCodeRef()).thenReturn("qr-ref");
+        var entity = new Payment();
+        var saved = new Payment();
+        var resultDTO = mock(PaymentDTO.class);
+        var salesConfig = buildSalesConfig(10.0, 100.0);
+        var enterpriseConfig = buildEnterpriseConfig(500.0, 500.0, 500.0, 500.0);
+        var activePartnership = buildActivePartnership();
+
+        when(salesConfigurationsService.getSalesConfigurationsBySalesId(1L)).thenReturn(salesConfig);
+        when(enterpriseConfigurationService.getEnterpriseConfigurationByEnterpriseId(2L)).thenReturn(enterpriseConfig);
+        when(partnershipService.getPartnershipsBySalesIdAndEnterpriseId(1L, 2L)).thenReturn(activePartnership);
+        when(paymentRepository.findAllPaymentsByClientIdAndModule(3L, "RESTAURATION")).thenReturn(0.0);
+        when(paymentMapper.asEntity(dto)).thenReturn(entity);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(saved);
+        when(paymentMapper.asDTO(saved)).thenReturn(resultDTO);
+
+        var result = paymentService.createPayment(dto);
+
+        assertThat(result).isEqualTo(resultDTO);
+        verify(qrCodeService).consumeClientQrCode("qr-ref", 3L);
+    }
+
+    @Test
+    void createPayment_withoutQrCodeRef_doesNotConsumeQrCode() {
+        var dto = buildPaymentDTO(Modules.RESTAURATION, 50.0);
+        when(dto.qrCodeRef()).thenReturn(null);
+        var entity = new Payment();
+        var saved = new Payment();
+        var resultDTO = mock(PaymentDTO.class);
+        var salesConfig = buildSalesConfig(10.0, 100.0);
+        var enterpriseConfig = buildEnterpriseConfig(500.0, 500.0, 500.0, 500.0);
+        var activePartnership = buildActivePartnership();
+
+        when(salesConfigurationsService.getSalesConfigurationsBySalesId(1L)).thenReturn(salesConfig);
+        when(enterpriseConfigurationService.getEnterpriseConfigurationByEnterpriseId(2L)).thenReturn(enterpriseConfig);
+        when(partnershipService.getPartnershipsBySalesIdAndEnterpriseId(1L, 2L)).thenReturn(activePartnership);
+        when(paymentRepository.findAllPaymentsByClientIdAndModule(3L, "RESTAURATION")).thenReturn(0.0);
+        when(paymentMapper.asEntity(dto)).thenReturn(entity);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(saved);
+        when(paymentMapper.asDTO(saved)).thenReturn(resultDTO);
+
+        paymentService.createPayment(dto);
+
+        verify(qrCodeService, never()).consumeClientQrCode(anyString(), anyLong());
+    }
+
+    @Test
     void updatePayment_throwsWhenNotFound() {
         when(paymentRepository.findById(99L)).thenReturn(Optional.empty());
 
@@ -391,6 +459,19 @@ class PaymentServiceImplTest {
 
         Page<PaymentDTO> result = paymentService.getPaymentByFilters(
                 null, null, null, null, null, null, null, null, null, null, Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getPaymentByFilters_withEmptyRef_returnsPage() {
+        var page = new PageImpl<>(List.of(new Payment()));
+        when(paymentRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(paymentMapper.asDTO(any(Payment.class))).thenReturn(mock(PaymentDTO.class));
+
+        Page<PaymentDTO> result = paymentService.getPaymentByFilters(
+                null, "", null, null, null, null, null, null, null, null, Pageable.unpaged());
 
         assertThat(result).hasSize(1);
     }

--- a/src/test/java/com/sn/onepay/services/impl/QRCodeServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/QRCodeServiceImplTest.java
@@ -4,12 +4,15 @@ import com.sn.onepay.entity.Cashier;
 import com.sn.onepay.entity.Client;
 import com.sn.onepay.entity.Enterprise;
 import com.sn.onepay.entity.EnterpriseConfiguration;
+import com.sn.onepay.entity.QRCodeClient;
 import com.sn.onepay.entity.Sales;
 import com.sn.onepay.entity.SalesConfigurations;
+import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.repository.CashierRepository;
 import com.sn.onepay.repository.ClientRepository;
 import com.sn.onepay.repository.EnterpriseConfigurationRepository;
+import com.sn.onepay.repository.QRCodeClientRepository;
 import com.sn.onepay.repository.SalesConfigurationsRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +40,9 @@ class QRCodeServiceImplTest {
 
     @Mock
     EnterpriseConfigurationRepository enterpriseConfigurationRepository;
+
+    @Mock
+    QRCodeClientRepository qrCodeClientRepository;
 
     @InjectMocks
     QRCodeServiceImpl qrCodeService;
@@ -103,7 +109,7 @@ class QRCodeServiceImplTest {
     }
 
     @Test
-    void getClientQrCode_happyPath() {
+    void getClientQrCode_happyPath_persistsQrCode() {
         var client = mock(Client.class);
         var enterprise = mock(Enterprise.class);
         when(client.getEnterprise()).thenReturn(enterprise);
@@ -116,11 +122,82 @@ class QRCodeServiceImplTest {
         when(config.getMaxAmountMarket()).thenReturn(300.0);
         when(enterpriseConfigurationRepository.findByEnterprise(enterprise)).thenReturn(config);
 
+        when(qrCodeClientRepository.save(any(QRCodeClient.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
         var result = qrCodeService.getClientQrCode(1L);
 
         assertThat(result).isNotNull();
+        assertThat(result.ref()).isNotNull();
         assertThat(result.clientId()).isEqualTo(1L);
+        assertThat(result.used()).isFalse();
         assertThat(result.maxAmountRestauration()).isEqualTo(500.0);
         assertThat(result.maxAmountMarket()).isEqualTo(300.0);
+
+        verify(qrCodeClientRepository).save(any(QRCodeClient.class));
+    }
+
+    @Test
+    void consumeClientQrCode_throwsWhenRefNotFound() {
+        when(qrCodeClientRepository.findByRef("unknown")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> qrCodeService.consumeClientQrCode("unknown", 1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void consumeClientQrCode_throwsWhenInactive() {
+        var qrCode = new QRCodeClient();
+        qrCode.setActive(false);
+        when(qrCodeClientRepository.findByRef("ref")).thenReturn(Optional.of(qrCode));
+
+        assertThatThrownBy(() -> qrCodeService.consumeClientQrCode("ref", 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("invalide");
+    }
+
+    @Test
+    void consumeClientQrCode_throwsWhenClientMismatch() {
+        var client = mock(Client.class);
+        when(client.getId()).thenReturn(2L);
+        var qrCode = new QRCodeClient();
+        qrCode.setActive(true);
+        qrCode.setClient(client);
+        when(qrCodeClientRepository.findByRef("ref")).thenReturn(Optional.of(qrCode));
+
+        assertThatThrownBy(() -> qrCodeService.consumeClientQrCode("ref", 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("invalide");
+    }
+
+    @Test
+    void consumeClientQrCode_throwsWhenAlreadyUsed() {
+        var client = mock(Client.class);
+        when(client.getId()).thenReturn(1L);
+        var qrCode = new QRCodeClient();
+        qrCode.setActive(true);
+        qrCode.setUsed(true);
+        qrCode.setClient(client);
+        when(qrCodeClientRepository.findByRef("ref")).thenReturn(Optional.of(qrCode));
+
+        assertThatThrownBy(() -> qrCodeService.consumeClientQrCode("ref", 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("déjà utilisé");
+    }
+
+    @Test
+    void consumeClientQrCode_marksAsUsed() {
+        var client = mock(Client.class);
+        when(client.getId()).thenReturn(1L);
+        var qrCode = new QRCodeClient();
+        qrCode.setActive(true);
+        qrCode.setUsed(false);
+        qrCode.setClient(client);
+        when(qrCodeClientRepository.findByRef("ref")).thenReturn(Optional.of(qrCode));
+        when(qrCodeClientRepository.saveAndFlush(qrCode)).thenReturn(qrCode);
+
+        qrCodeService.consumeClientQrCode("ref", 1L);
+
+        assertThat(qrCode.isUsed()).isTrue();
+        verify(qrCodeClientRepository).saveAndFlush(qrCode);
     }
 }


### PR DESCRIPTION
- New QRCodeClient entity persisted on GET /qrcode/client (single-use ref)
- PaymentDTO gains optional qrCodeRef, consumed atomically with the payment
- Liquibase changeset for qrcodeclient table + JPA_SEQUENCE init
- 9 new unit tests (184 total, 0 failures)