### PR TITLE
feat: implement Bills CRUD with period field and enable bean validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>

--- a/src/main/java/com/sn/onepay/controller/BillsController.java
+++ b/src/main/java/com/sn/onepay/controller/BillsController.java
@@ -1,6 +1,7 @@
 package com.sn.onepay.controller;
 
 import com.sn.onepay.dto.BillsDTO;
+import com.sn.onepay.enumeration.BillStatus;
 import com.sn.onepay.services.BillsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,12 +12,22 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @Slf4j
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -27,7 +38,7 @@ public class BillsController {
 
     final BillsService billsService;
 
-    @Operation(summary = "Create a new bills", description = "This endpoint is for creating a new bills")
+    @Operation(summary = "Create a new bill", description = "This endpoint is for creating a new bill")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Success"),
             @ApiResponse(responseCode = "400", description = "Incorrect request"),
@@ -36,6 +47,54 @@ public class BillsController {
     @PostMapping(consumes = "application/json")
     @ResponseStatus(HttpStatus.CREATED)
     public BillsDTO createBills(@Parameter(description = "Bills body for creation", required = true) @RequestBody @Valid BillsDTO bills) {
-        return bills;
+        return billsService.createBills(bills);
+    }
+
+    @Operation(summary = "Update a bill", description = "This endpoint is for updating a bill")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @PutMapping(value = "/{billsId}")
+    @ResponseStatus(HttpStatus.OK)
+    public BillsDTO updateBills(@Parameter(description = "Bills body to update", required = true) @RequestBody @Valid BillsDTO bills,
+                                @Parameter(description = "Bills id to update", required = true) @PathVariable(name = "billsId") Long billsId) {
+        return billsService.updateBills(bills, billsId);
+    }
+
+    @Operation(summary = "Get bills by filter", description = "This endpoint is for getting bills by filter")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public Page<BillsDTO> getBillsByFilters(
+            @Parameter(description = "Filter by bill ID") @RequestParam(required = false) Long id,
+            @Parameter(description = "Filter by reference (partial match)") @RequestParam(required = false) String ref,
+            @Parameter(description = "Filter by partnership ID") @RequestParam(required = false) Long partnershipId,
+            @Parameter(description = "Filter by bill status (PAYED or UNPAYED)") @RequestParam(required = false) BillStatus billStatus,
+            @Parameter(description = "Filter by billed period label (e.g. 2026-07)") @RequestParam(required = false) String period,
+            @Parameter(description = "Filter by active status (true or false)") @RequestParam(required = false) Boolean active,
+            @Parameter(description = "Filter bills starting after this date (ISO format)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(description = "Filter bills ending before this date (ISO format)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @Parameter(description = "Filter records created after this date (ISO format)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime creationDate,
+            @Parameter(description = "Filter records modified before this date (ISO format)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime modificationDate,
+            Pageable pageable) {
+        return billsService.getBillsByFilters(id, ref, partnershipId, billStatus, period, active, startDate, endDate, creationDate, modificationDate, pageable);
+    }
+
+    @Operation(summary = "Delete a bill by id", description = "This endpoint is for deleting a bill by id (logical deletion)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "400", description = "Incorrect request"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @DeleteMapping(value = "/{billsId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteBills(@Parameter(description = "Bills id to delete", required = true) @PathVariable(name = "billsId") Long billsId) {
+        billsService.deleteBills(billsId);
     }
 }

--- a/src/main/java/com/sn/onepay/dto/BillsDTO.java
+++ b/src/main/java/com/sn/onepay/dto/BillsDTO.java
@@ -1,8 +1,8 @@
 package com.sn.onepay.dto;
 
-import com.sn.onepay.entity.Partnership;
 import com.sn.onepay.enumeration.BillStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
@@ -15,19 +15,31 @@ public record BillsDTO(
         String ref,
 
         @Schema(name = "partnership", description = "Bills partnership")
-        Partnership partnership,
+        @NotNull(message = "Partnership can not be null")
+        PartnershipDTO partnership,
 
         @Schema(name = "startDate", description = "Bills start date")
+        @NotNull(message = "Start date can not be null")
         LocalDateTime startDate,
 
         @Schema(name = "endDate", description = "Bills end date")
+        @NotNull(message = "End date can not be null")
         LocalDateTime endDate,
 
         @Schema(name = "totalAmount", description = "Bills total amount")
+        @NotNull(message = "Total amount can not be null")
         Double totalAmount,
 
         @Schema(name = "billStatus", description = "Bills status")
+        @NotNull(message = "Bill status can not be null")
         BillStatus billStatus,
+
+        @Schema(name = "period", description = "Billed period label (e.g. 2026-07)")
+        @NotNull(message = "Period can not be null")
+        String period,
+
+        @Schema(name = "active", description = "Whether the bill is active")
+        Boolean active,
 
         @Schema(name = "creationDate", description = "Bills date of creation")
         LocalDateTime creationDate,

--- a/src/main/java/com/sn/onepay/entity/Bills.java
+++ b/src/main/java/com/sn/onepay/entity/Bills.java
@@ -59,6 +59,12 @@ public class Bills {
     @Enumerated(EnumType.STRING)
     BillStatus billStatus;
 
+    @Column(name = "Period", nullable = false)
+    String period;
+
+    @Column(name = "Active", nullable = false)
+    boolean active;
+
     @CreatedDate
     @Column(name = "CreationDate", updatable = false)
     LocalDateTime creationDate;

--- a/src/main/java/com/sn/onepay/enumeration/StateStatus.java
+++ b/src/main/java/com/sn/onepay/enumeration/StateStatus.java
@@ -1,7 +1,0 @@
-package com.sn.onepay.enumeration;
-
-public enum StateStatus {
-    ACTIVE,
-
-    INACTIVE
-}

--- a/src/main/java/com/sn/onepay/mapper/BillsMapper.java
+++ b/src/main/java/com/sn/onepay/mapper/BillsMapper.java
@@ -5,6 +5,6 @@ import com.sn.onepay.entity.Bills;
 import com.sn.onepay.utils.IMapper;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {PartnershipMapper.class})
 public interface BillsMapper extends IMapper<Bills, BillsDTO> {
 }

--- a/src/main/java/com/sn/onepay/services/BillsService.java
+++ b/src/main/java/com/sn/onepay/services/BillsService.java
@@ -1,4 +1,19 @@
 package com.sn.onepay.services;
 
+import com.sn.onepay.dto.BillsDTO;
+import com.sn.onepay.enumeration.BillStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+
 public interface BillsService {
+
+    BillsDTO createBills(BillsDTO billsDTO);
+
+    BillsDTO updateBills(BillsDTO billsDTO, Long billsId);
+
+    void deleteBills(Long billsId);
+
+    Page<BillsDTO> getBillsByFilters(Long id, String ref, Long partnershipId, BillStatus billStatus, String period, Boolean active, LocalDateTime startDate, LocalDateTime endDate, LocalDateTime creationDate, LocalDateTime modificationDate, Pageable pageable);
 }

--- a/src/main/java/com/sn/onepay/services/impl/BillsServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/BillsServiceImpl.java
@@ -1,12 +1,25 @@
 package com.sn.onepay.services.impl;
 
+import com.querydsl.core.BooleanBuilder;
+import com.sn.onepay.dto.BillsDTO;
+import com.sn.onepay.entity.Bills;
+import com.sn.onepay.entity.QBills;
+import com.sn.onepay.enumeration.BillStatus;
+import com.sn.onepay.exceptions.ResourceNotFoundException;
+import com.sn.onepay.mapper.BillsMapper;
+import com.sn.onepay.repository.BillsRepository;
 import com.sn.onepay.services.BillsService;
 import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @Slf4j
@@ -14,4 +27,95 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Transactional
 public class BillsServiceImpl implements BillsService {
+
+    final BillsRepository billsRepository;
+    final BillsMapper billsMapper;
+
+    @Override
+    public BillsDTO createBills(BillsDTO billsDTO) {
+
+        Bills bills = billsMapper.asEntity(billsDTO);
+        bills.setRef(UUID.randomUUID().toString());
+        bills.setActive(true);
+        var savedBills = billsRepository.save(bills);
+
+        log.info("Created new Bills: {}", savedBills);
+        log.trace("Created new Bills with id: {}", savedBills.getId());
+
+        return billsMapper.asDTO(savedBills);
+    }
+
+    @Override
+    public BillsDTO updateBills(BillsDTO billsDTO, Long billsId) {
+
+        Bills existing = billsRepository.findById(billsId)
+                .orElseThrow(() -> new ResourceNotFoundException("Bills", "ID", billsId));
+
+        if (billsDTO.startDate() != null) existing.setStartDate(billsDTO.startDate());
+        if (billsDTO.endDate() != null) existing.setEndDate(billsDTO.endDate());
+        if (billsDTO.totalAmount() != null) existing.setTotalAmount(billsDTO.totalAmount());
+        if (billsDTO.billStatus() != null) existing.setBillStatus(billsDTO.billStatus());
+        if (billsDTO.period() != null) existing.setPeriod(billsDTO.period());
+        if (billsDTO.active() != null) existing.setActive(billsDTO.active());
+
+        var updated = billsRepository.saveAndFlush(existing);
+
+        log.info("Updated Bills: {}", updated);
+        log.trace("Updated Bills with id: {}", updated.getId());
+
+        return billsMapper.asDTO(updated);
+    }
+
+    @Override
+    public void deleteBills(Long billsId) {
+
+        /*Implements logical deletion*/
+        Bills bills = billsRepository.findById(billsId).orElseThrow(() -> new ResourceNotFoundException("Bills", "ID", billsId));
+        bills.setActive(false);
+        billsRepository.saveAndFlush(bills);
+
+        log.info("Deleted Bills: {}", billsId);
+        log.trace("Deleted Bills with id: {}", billsId);
+    }
+
+    @Override
+    public Page<BillsDTO> getBillsByFilters(Long id, String ref, Long partnershipId, BillStatus billStatus, String period, Boolean active, LocalDateTime startDate, LocalDateTime endDate, LocalDateTime creationDate, LocalDateTime modificationDate, Pageable pageable) {
+
+        QBills bills = QBills.bills;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (id != null) {
+            builder.and(bills.id.eq(id));
+        }
+        if (ref != null && !ref.isEmpty()) {
+            builder.and(bills.ref.containsIgnoreCase(ref));
+        }
+        if (partnershipId != null) {
+            builder.and(bills.partnership.id.eq(partnershipId));
+        }
+        if (billStatus != null) {
+            builder.and(bills.billStatus.eq(billStatus));
+        }
+        if (period != null && !period.isEmpty()) {
+            builder.and(bills.period.eq(period));
+        }
+        if (active != null) {
+            builder.and(bills.active.eq(active));
+        }
+        if (startDate != null) {
+            builder.and(bills.startDate.goe(startDate));
+        }
+        if (endDate != null) {
+            builder.and(bills.endDate.loe(endDate));
+        }
+        if (creationDate != null) {
+            builder.and(bills.creationDate.goe(creationDate));
+        }
+        if (modificationDate != null) {
+            builder.and(bills.modificationDate.loe(modificationDate));
+        }
+
+        Page<Bills> result = billsRepository.findAll(builder, pageable);
+        return result.map(billsMapper::asDTO);
+    }
 }

--- a/src/main/resources/db/changelog/db.changelog-1.0.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.0.xml
@@ -587,4 +587,25 @@
         </insert>
 
     </changeSet>
+
+    <changeSet id="1.0.0-bills-period-active" author="mouhamed">
+
+        <addColumn tableName="bills">
+            <column name="period" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="bills">
+            <column name="active" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <insert tableName="jpa_sequence">
+            <column name="seq_key" value="BillsId"/>
+            <column name="seq_value" valueNumeric="1"/>
+        </insert>
+
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/com/sn/onepay/controller/BillsControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/BillsControllerTest.java
@@ -1,18 +1,34 @@
 package com.sn.onepay.controller;
 
+import com.sn.onepay.dto.BillsDTO;
 import com.sn.onepay.services.BillsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BillsController.class)
 class BillsControllerTest extends BaseControllerTest {
+
+    static final String VALID_BODY = "{\"partnership\":{\"id\":1,\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100}}," +
+            "\"startDate\":\"2026-07-01T00:00:00\",\"endDate\":\"2026-07-31T23:59:59\"," +
+            "\"totalAmount\":5000.0,\"billStatus\":\"UNPAYED\",\"period\":\"2026-07\"}";
 
     @Autowired
     MockMvc mockMvc;
@@ -22,9 +38,46 @@ class BillsControllerTest extends BaseControllerTest {
 
     @Test
     void createBills_returns201() throws Exception {
+        when(billsService.createBills(any())).thenReturn(mock(BillsDTO.class));
+
+        mockMvc.perform(post("/v1/onepay/bills")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createBills_returns400WhenBodyInvalid() throws Exception {
         mockMvc.perform(post("/v1/onepay/bills")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
-                .andExpect(status().isCreated());
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateBills_returns200() throws Exception {
+        when(billsService.updateBills(any(), anyLong())).thenReturn(mock(BillsDTO.class));
+
+        mockMvc.perform(put("/v1/onepay/bills/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_BODY))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getBillsByFilters_returns200() throws Exception {
+        when(billsService.getBillsByFilters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/v1/onepay/bills"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deleteBills_returns200() throws Exception {
+        doNothing().when(billsService).deleteBills(anyLong());
+
+        mockMvc.perform(delete("/v1/onepay/bills/1"))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/sn/onepay/controller/CashierControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/CashierControllerTest.java
@@ -35,7 +35,7 @@ class CashierControllerTest extends BaseControllerTest {
 
         mockMvc.perform(post("/v1/onepay/cashier")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"firstname\":\"Jean\",\"lastname\":\"Pierre\",\"username\":\"jp\",\"role\":\"CASHIER\",\"status\":\"ACTIVE\"}"))
+                        .content("{\"firstname\":\"Jean\",\"lastname\":\"Pierre\",\"username\":\"jp\",\"email\":\"jp@mail.com\",\"role\":\"CASHIER\",\"status\":\"ACTIVE\"}"))
                 .andExpect(status().isCreated());
     }
 
@@ -45,7 +45,7 @@ class CashierControllerTest extends BaseControllerTest {
 
         mockMvc.perform(put("/v1/onepay/cashier/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"firstname\":\"Jean\",\"lastname\":\"Pierre\",\"username\":\"jp\",\"role\":\"CASHIER\",\"status\":\"ACTIVE\"}"))
+                        .content("{\"firstname\":\"Jean\",\"lastname\":\"Pierre\",\"username\":\"jp\",\"email\":\"jp@mail.com\",\"role\":\"CASHIER\",\"status\":\"ACTIVE\"}"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/sn/onepay/controller/ClientControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/ClientControllerTest.java
@@ -38,7 +38,7 @@ class ClientControllerTest extends BaseControllerTest {
 
         mockMvc.perform(post("/v1/onepay/client")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"firstname\":\"John\",\"lastname\":\"Doe\",\"username\":\"jdoe\",\"role\":\"CLIENT\",\"status\":\"ACTIVE\"}"))
+                        .content("{\"firstname\":\"John\",\"lastname\":\"Doe\",\"username\":\"jdoe\",\"email\":\"jdoe@mail.com\",\"role\":\"CLIENT\",\"status\":\"ACTIVE\"}"))
                 .andExpect(status().isCreated());
     }
 
@@ -48,7 +48,7 @@ class ClientControllerTest extends BaseControllerTest {
 
         mockMvc.perform(put("/v1/onepay/client/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"firstname\":\"John\",\"lastname\":\"Doe\",\"username\":\"jdoe\",\"role\":\"CLIENT\",\"status\":\"ACTIVE\"}"))
+                        .content("{\"firstname\":\"John\",\"lastname\":\"Doe\",\"username\":\"jdoe\",\"email\":\"jdoe@mail.com\",\"role\":\"CLIENT\",\"status\":\"ACTIVE\"}"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/sn/onepay/controller/PartnershipControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/PartnershipControllerTest.java
@@ -38,7 +38,7 @@ class PartnershipControllerTest extends BaseControllerTest {
 
         mockMvc.perform(post("/v1/onepay/partnership")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"status\":\"ACTIVE\"}"))
+                        .content("{\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"active\":true}"))
                 .andExpect(status().isCreated());
     }
 
@@ -48,7 +48,7 @@ class PartnershipControllerTest extends BaseControllerTest {
 
         mockMvc.perform(put("/v1/onepay/partnership/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"status\":\"ACTIVE\"}"))
+                        .content("{\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"active\":true}"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/sn/onepay/services/impl/BillsServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/BillsServiceImplTest.java
@@ -1,0 +1,194 @@
+package com.sn.onepay.services.impl;
+
+import com.sn.onepay.dto.BillsDTO;
+import com.sn.onepay.entity.Bills;
+import com.sn.onepay.enumeration.BillStatus;
+import com.sn.onepay.exceptions.ResourceNotFoundException;
+import com.sn.onepay.mapper.BillsMapper;
+import com.sn.onepay.repository.BillsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BillsServiceImplTest {
+
+    @Mock
+    BillsRepository billsRepository;
+
+    @Mock
+    BillsMapper billsMapper;
+
+    @InjectMocks
+    BillsServiceImpl billsService;
+
+    @Test
+    void createBills_happyPath() {
+        var dto = mock(BillsDTO.class);
+        var entity = new Bills();
+        var saved = new Bills();
+        var resultDTO = mock(BillsDTO.class);
+
+        when(billsMapper.asEntity(dto)).thenReturn(entity);
+        when(billsRepository.save(any(Bills.class))).thenReturn(saved);
+        when(billsMapper.asDTO(saved)).thenReturn(resultDTO);
+
+        var result = billsService.createBills(dto);
+
+        assertThat(result).isEqualTo(resultDTO);
+        assertThat(entity.isActive()).isTrue();
+        assertThat(entity.getRef()).isNotNull();
+    }
+
+    @Test
+    void updateBills_throwsWhenNotFound() {
+        when(billsRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> billsService.updateBills(mock(BillsDTO.class), 99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void updateBills_modifiesFieldsAndSaves() {
+        var startDate = LocalDateTime.of(2026, 7, 1, 0, 0);
+        var endDate = LocalDateTime.of(2026, 7, 31, 23, 59);
+
+        var dto = mock(BillsDTO.class);
+        when(dto.startDate()).thenReturn(startDate);
+        when(dto.endDate()).thenReturn(endDate);
+        when(dto.totalAmount()).thenReturn(5000.0);
+        when(dto.billStatus()).thenReturn(BillStatus.PAYED);
+        when(dto.period()).thenReturn("2026-07");
+        when(dto.active()).thenReturn(false);
+
+        var existing = new Bills();
+        existing.setActive(true);
+        var updated = new Bills();
+        var resultDTO = mock(BillsDTO.class);
+
+        when(billsRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(billsRepository.saveAndFlush(existing)).thenReturn(updated);
+        when(billsMapper.asDTO(updated)).thenReturn(resultDTO);
+
+        var result = billsService.updateBills(dto, 1L);
+
+        assertThat(existing.getStartDate()).isEqualTo(startDate);
+        assertThat(existing.getEndDate()).isEqualTo(endDate);
+        assertThat(existing.getTotalAmount()).isEqualTo(5000.0);
+        assertThat(existing.getBillStatus()).isEqualTo(BillStatus.PAYED);
+        assertThat(existing.getPeriod()).isEqualTo("2026-07");
+        assertThat(existing.isActive()).isFalse();
+        assertThat(result).isEqualTo(resultDTO);
+    }
+
+    @Test
+    void updateBills_withNullFields_doesNotChangeFields() {
+        var startDate = LocalDateTime.of(2026, 7, 1, 0, 0);
+
+        var dto = mock(BillsDTO.class);
+        when(dto.startDate()).thenReturn(null);
+        when(dto.endDate()).thenReturn(null);
+        when(dto.totalAmount()).thenReturn(null);
+        when(dto.billStatus()).thenReturn(null);
+        when(dto.period()).thenReturn(null);
+        when(dto.active()).thenReturn(null);
+
+        var existing = new Bills();
+        existing.setStartDate(startDate);
+        existing.setTotalAmount(3000.0);
+        existing.setBillStatus(BillStatus.UNPAYED);
+        existing.setPeriod("2026-06");
+        existing.setActive(true);
+
+        var updated = new Bills();
+        var resultDTO = mock(BillsDTO.class);
+
+        when(billsRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(billsRepository.saveAndFlush(existing)).thenReturn(updated);
+        when(billsMapper.asDTO(updated)).thenReturn(resultDTO);
+
+        billsService.updateBills(dto, 1L);
+
+        assertThat(existing.getStartDate()).isEqualTo(startDate);
+        assertThat(existing.getTotalAmount()).isEqualTo(3000.0);
+        assertThat(existing.getBillStatus()).isEqualTo(BillStatus.UNPAYED);
+        assertThat(existing.getPeriod()).isEqualTo("2026-06");
+        assertThat(existing.isActive()).isTrue();
+    }
+
+    @Test
+    void deleteBills_throwsWhenNotFound() {
+        when(billsRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> billsService.deleteBills(99L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void deleteBills_setsActiveToFalse() {
+        var bills = new Bills();
+        bills.setActive(true);
+        when(billsRepository.findById(1L)).thenReturn(Optional.of(bills));
+        when(billsRepository.saveAndFlush(bills)).thenReturn(bills);
+
+        billsService.deleteBills(1L);
+
+        assertThat(bills.isActive()).isFalse();
+        verify(billsRepository).saveAndFlush(bills);
+    }
+
+    @Test
+    void getBillsByFilters_withNullParams_returnsPage() {
+        var page = new PageImpl<>(List.of(new Bills()));
+        when(billsRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(billsMapper.asDTO(any(Bills.class))).thenReturn(mock(BillsDTO.class));
+
+        Page<BillsDTO> result = billsService.getBillsByFilters(
+                null, null, null, null, null, null, null, null, null, null, Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getBillsByFilters_withAllParamsSet_returnsPage() {
+        var page = new PageImpl<>(List.of(new Bills()));
+        when(billsRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(billsMapper.asDTO(any(Bills.class))).thenReturn(mock(BillsDTO.class));
+
+        Page<BillsDTO> result = billsService.getBillsByFilters(
+                1L, "REF", 2L, BillStatus.UNPAYED, "2026-07", true,
+                LocalDateTime.now().minusMonths(1), LocalDateTime.now(),
+                LocalDateTime.now().minusDays(1), LocalDateTime.now(), Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getBillsByFilters_withEmptyRefAndPeriod_returnsPage() {
+        var page = new PageImpl<>(List.of(new Bills()));
+        when(billsRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(billsMapper.asDTO(any(Bills.class))).thenReturn(mock(BillsDTO.class));
+
+        Page<BillsDTO> result = billsService.getBillsByFilters(
+                null, "", null, null, "", null, null, null, null, null, Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+}


### PR DESCRIPTION
- Bills entity: add period (billed period label) and active (logical deletion)
- BillsDTO: use PartnershipDTO instead of JPA entity, add @NotNull constraints
- Full service: create with UUID ref, update existing entity, logical delete, QueryDSL filtered pagination
- Real controller CRUD (previous POST echoed the body without persisting)
- Liquibase: bills period/active columns + JPA_SEQUENCE init for BillsId
- Add missing spring-boot-starter-validation: @Valid/@NotNull were silently ignored across the whole API; fix test payloads accordingly
- Remove unused StateStatus enum
- 13 new unit tests (197 total, 0 failures)