### PR TITLE
feat: DTOs de création/update par IDs pour Subvention et EmployeeGroup

### DIFF
--- a/src/main/java/com/sn/onepay/controller/EmployeeGroupController.java
+++ b/src/main/java/com/sn/onepay/controller/EmployeeGroupController.java
@@ -1,6 +1,8 @@
 package com.sn.onepay.controller;
 
+import com.sn.onepay.dto.EmployeeGroupCreateDTO;
 import com.sn.onepay.dto.EmployeeGroupDTO;
+import com.sn.onepay.dto.EmployeeGroupUpdateDTO;
 import com.sn.onepay.services.EmployeeGroupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,7 +47,7 @@ public class EmployeeGroupController {
     })
     @PostMapping(consumes = "application/json")
     @ResponseStatus(HttpStatus.CREATED)
-    public EmployeeGroupDTO createEmployeeGroup(@Parameter(description = "EmployeeGroup body for creation", required = true) @RequestBody @Valid EmployeeGroupDTO employeeGroup) {
+    public EmployeeGroupDTO createEmployeeGroup(@Parameter(description = "EmployeeGroup body for creation", required = true) @RequestBody @Valid EmployeeGroupCreateDTO employeeGroup) {
         return employeeGroupService.createEmployeeGroup(employeeGroup);
     }
 
@@ -57,7 +59,7 @@ public class EmployeeGroupController {
     })
     @PutMapping(value = "/{employeeGroupId}")
     @ResponseStatus(HttpStatus.OK)
-    public EmployeeGroupDTO updateEmployeeGroup(@Parameter(description = "EmployeeGroup body to update", required = true) @RequestBody @Valid EmployeeGroupDTO employeeGroup,
+    public EmployeeGroupDTO updateEmployeeGroup(@Parameter(description = "EmployeeGroup body to update", required = true) @RequestBody @Valid EmployeeGroupUpdateDTO employeeGroup,
                                                 @Parameter(description = "EmployeeGroup id to update", required = true) @PathVariable(name = "employeeGroupId") Long employeeGroupId) {
         return employeeGroupService.updateEmployeeGroup(employeeGroup, employeeGroupId);
     }

--- a/src/main/java/com/sn/onepay/controller/SubventionController.java
+++ b/src/main/java/com/sn/onepay/controller/SubventionController.java
@@ -1,6 +1,8 @@
 package com.sn.onepay.controller;
 
+import com.sn.onepay.dto.SubventionCreateDTO;
 import com.sn.onepay.dto.SubventionDTO;
+import com.sn.onepay.dto.SubventionUpdateDTO;
 import com.sn.onepay.services.SubventionService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -45,7 +47,7 @@ public class SubventionController {
     })
     @PostMapping(consumes = "application/json")
     @ResponseStatus(HttpStatus.CREATED)
-    public SubventionDTO createSubvention(@Parameter(description = "Subvention body for creation", required = true) @RequestBody @Valid SubventionDTO subvention) {
+    public SubventionDTO createSubvention(@Parameter(description = "Subvention body for creation", required = true) @RequestBody @Valid SubventionCreateDTO subvention) {
         return subventionService.createSubvention(subvention);
     }
 
@@ -57,7 +59,7 @@ public class SubventionController {
     })
     @PutMapping(value = "/{subventionId}")
     @ResponseStatus(HttpStatus.OK)
-    public SubventionDTO updateSubvention(@Parameter(description = "Subvention body to update", required = true) @RequestBody @Valid SubventionDTO subvention,
+    public SubventionDTO updateSubvention(@Parameter(description = "Subvention body to update", required = true) @RequestBody @Valid SubventionUpdateDTO subvention,
                                           @Parameter(description = "Subvention id to update", required = true) @PathVariable(name = "subventionId") Long subventionId) {
         return subventionService.updateSubvention(subvention, subventionId);
     }

--- a/src/main/java/com/sn/onepay/dto/EmployeeGroupCreateDTO.java
+++ b/src/main/java/com/sn/onepay/dto/EmployeeGroupCreateDTO.java
@@ -1,0 +1,21 @@
+package com.sn.onepay.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record EmployeeGroupCreateDTO(
+
+        @Schema(name = "name", description = "EmployeeGroup Name")
+        @NotNull
+        String name,
+
+        @Schema(name = "enterpriseId", description = "Identifier of the enterprise owning this group")
+        @NotNull
+        Long enterpriseId,
+
+        @Schema(name = "clientIds", description = "Identifiers of the clients (employees) in this group")
+        List<Long> clientIds
+) {
+}

--- a/src/main/java/com/sn/onepay/dto/EmployeeGroupUpdateDTO.java
+++ b/src/main/java/com/sn/onepay/dto/EmployeeGroupUpdateDTO.java
@@ -1,0 +1,18 @@
+package com.sn.onepay.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record EmployeeGroupUpdateDTO(
+
+        @Schema(name = "name", description = "EmployeeGroup Name")
+        String name,
+
+        @Schema(name = "clientIds", description = "Identifiers of the clients (employees) replacing the current group members")
+        List<Long> clientIds,
+
+        @Schema(name = "active", description = "Whether the EmployeeGroup is active")
+        Boolean active
+) {
+}

--- a/src/main/java/com/sn/onepay/dto/SubventionCreateDTO.java
+++ b/src/main/java/com/sn/onepay/dto/SubventionCreateDTO.java
@@ -1,0 +1,24 @@
+package com.sn.onepay.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record SubventionCreateDTO(
+
+        @Schema(name = "employeePercent", description = "Employee contribution percentage")
+        @NotNull
+        Double employeePercent,
+
+        @Schema(name = "employerPercent", description = "Employer contribution percentage")
+        @NotNull
+        Double employerPercent,
+
+        @Schema(name = "partnershipId", description = "Identifier of the partnership linked to this subvention")
+        @NotNull
+        Long partnershipId,
+
+        @Schema(name = "employeeGroupId", description = "Identifier of the employee group this subvention applies to")
+        @NotNull
+        Long employeeGroupId
+) {
+}

--- a/src/main/java/com/sn/onepay/dto/SubventionUpdateDTO.java
+++ b/src/main/java/com/sn/onepay/dto/SubventionUpdateDTO.java
@@ -1,0 +1,16 @@
+package com.sn.onepay.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record SubventionUpdateDTO(
+
+        @Schema(name = "employeePercent", description = "Employee contribution percentage (must be provided together with employerPercent)")
+        Double employeePercent,
+
+        @Schema(name = "employerPercent", description = "Employer contribution percentage (must be provided together with employeePercent)")
+        Double employerPercent,
+
+        @Schema(name = "active", description = "Whether the Subvention is active")
+        Boolean active
+) {
+}

--- a/src/main/java/com/sn/onepay/services/EmployeeGroupService.java
+++ b/src/main/java/com/sn/onepay/services/EmployeeGroupService.java
@@ -1,6 +1,8 @@
 package com.sn.onepay.services;
 
+import com.sn.onepay.dto.EmployeeGroupCreateDTO;
 import com.sn.onepay.dto.EmployeeGroupDTO;
+import com.sn.onepay.dto.EmployeeGroupUpdateDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,9 +10,9 @@ import java.time.LocalDateTime;
 
 public interface EmployeeGroupService {
 
-    EmployeeGroupDTO createEmployeeGroup(EmployeeGroupDTO employeeGroupDTO);
+    EmployeeGroupDTO createEmployeeGroup(EmployeeGroupCreateDTO employeeGroupCreateDTO);
 
-    EmployeeGroupDTO updateEmployeeGroup(EmployeeGroupDTO employeeGroupDTO, Long employeeGroupId);
+    EmployeeGroupDTO updateEmployeeGroup(EmployeeGroupUpdateDTO employeeGroupUpdateDTO, Long employeeGroupId);
 
     void deleteEmployeeGroup(Long employeeGroupId);
 

--- a/src/main/java/com/sn/onepay/services/SubventionService.java
+++ b/src/main/java/com/sn/onepay/services/SubventionService.java
@@ -1,6 +1,8 @@
 package com.sn.onepay.services;
 
+import com.sn.onepay.dto.SubventionCreateDTO;
 import com.sn.onepay.dto.SubventionDTO;
+import com.sn.onepay.dto.SubventionUpdateDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,9 +10,9 @@ import java.time.LocalDateTime;
 
 public interface SubventionService {
 
-    SubventionDTO createSubvention(SubventionDTO subventionDTO);
+    SubventionDTO createSubvention(SubventionCreateDTO subventionCreateDTO);
 
-    SubventionDTO updateSubvention(SubventionDTO subventionDTO, Long subventionId);
+    SubventionDTO updateSubvention(SubventionUpdateDTO subventionUpdateDTO, Long subventionId);
 
     void deleteSubvention(Long subventionId);
 

--- a/src/main/java/com/sn/onepay/services/impl/EmployeeGroupServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/EmployeeGroupServiceImpl.java
@@ -1,12 +1,19 @@
 package com.sn.onepay.services.impl;
 
 import com.querydsl.core.BooleanBuilder;
+import com.sn.onepay.dto.EmployeeGroupCreateDTO;
 import com.sn.onepay.dto.EmployeeGroupDTO;
+import com.sn.onepay.dto.EmployeeGroupUpdateDTO;
+import com.sn.onepay.entity.Client;
 import com.sn.onepay.entity.EmployeeGroup;
+import com.sn.onepay.entity.Enterprise;
 import com.sn.onepay.entity.QEmployeeGroup;
+import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.mapper.EmployeeGroupMapper;
+import com.sn.onepay.repository.ClientRepository;
 import com.sn.onepay.repository.EmployeeGroupRepository;
+import com.sn.onepay.repository.EnterpriseRepository;
 import com.sn.onepay.services.EmployeeGroupService;
 import jakarta.transaction.Transactional;
 import lombok.AccessLevel;
@@ -18,6 +25,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -28,13 +37,23 @@ import java.util.UUID;
 public class EmployeeGroupServiceImpl implements EmployeeGroupService {
 
     final EmployeeGroupRepository employeeGroupRepository;
+    final EnterpriseRepository enterpriseRepository;
+    final ClientRepository clientRepository;
     final EmployeeGroupMapper employeeGroupMapper;
 
     @Override
-    public EmployeeGroupDTO createEmployeeGroup(EmployeeGroupDTO employeeGroupDTO) {
+    public EmployeeGroupDTO createEmployeeGroup(EmployeeGroupCreateDTO employeeGroupCreateDTO) {
 
-        EmployeeGroup group = employeeGroupMapper.asEntity(employeeGroupDTO);
+        Enterprise enterprise = enterpriseRepository.findById(employeeGroupCreateDTO.enterpriseId())
+                .orElseThrow(() -> new ResourceNotFoundException("Enterprise", "ID", employeeGroupCreateDTO.enterpriseId()));
+
+        EmployeeGroup group = new EmployeeGroup();
         group.setRef(UUID.randomUUID().toString());
+        group.setName(employeeGroupCreateDTO.name());
+        group.setEnterprise(enterprise);
+        if (employeeGroupCreateDTO.clientIds() != null) {
+            group.setClients(resolveClients(employeeGroupCreateDTO.clientIds(), enterprise));
+        }
         group.setActive(true);
         var savedGroup = employeeGroupRepository.save(group);
 
@@ -45,13 +64,16 @@ public class EmployeeGroupServiceImpl implements EmployeeGroupService {
     }
 
     @Override
-    public EmployeeGroupDTO updateEmployeeGroup(EmployeeGroupDTO employeeGroupDTO, Long employeeGroupId) {
+    public EmployeeGroupDTO updateEmployeeGroup(EmployeeGroupUpdateDTO employeeGroupUpdateDTO, Long employeeGroupId) {
 
         EmployeeGroup existing = employeeGroupRepository.findById(employeeGroupId)
                 .orElseThrow(() -> new ResourceNotFoundException("EmployeeGroup", "ID", employeeGroupId));
 
-        existing.setName(employeeGroupDTO.name());
-        if (employeeGroupDTO.active() != null) existing.setActive(employeeGroupDTO.active());
+        if (employeeGroupUpdateDTO.name() != null) existing.setName(employeeGroupUpdateDTO.name());
+        if (employeeGroupUpdateDTO.clientIds() != null) {
+            existing.setClients(resolveClients(employeeGroupUpdateDTO.clientIds(), existing.getEnterprise()));
+        }
+        if (employeeGroupUpdateDTO.active() != null) existing.setActive(employeeGroupUpdateDTO.active());
 
         var updated = employeeGroupRepository.saveAndFlush(existing);
 
@@ -102,5 +124,23 @@ public class EmployeeGroupServiceImpl implements EmployeeGroupService {
 
         Page<EmployeeGroup> result = employeeGroupRepository.findAll(builder, pageable);
         return result.map(employeeGroupMapper::asDTO);
+    }
+
+    private List<Client> resolveClients(List<Long> clientIds, Enterprise enterprise) {
+
+        List<Client> clients = new ArrayList<>();
+        for (Long clientId : clientIds) {
+            Client client = clientRepository.findById(clientId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Client", "ID", clientId));
+            if (!client.isActive()) {
+                throw new ObjectValidationException("Le client " + clientId + " est inactif");
+            }
+            if (client.getEnterprise() == null || enterprise == null
+                    || !client.getEnterprise().getId().equals(enterprise.getId())) {
+                throw new ObjectValidationException("Le client " + clientId + " n'appartient pas à l'entreprise du groupe");
+            }
+            clients.add(client);
+        }
+        return clients;
     }
 }

--- a/src/main/java/com/sn/onepay/services/impl/SubventionServiceImpl.java
+++ b/src/main/java/com/sn/onepay/services/impl/SubventionServiceImpl.java
@@ -1,12 +1,18 @@
 package com.sn.onepay.services.impl;
 
 import com.querydsl.core.BooleanBuilder;
+import com.sn.onepay.dto.SubventionCreateDTO;
 import com.sn.onepay.dto.SubventionDTO;
+import com.sn.onepay.dto.SubventionUpdateDTO;
+import com.sn.onepay.entity.EmployeeGroup;
+import com.sn.onepay.entity.Partnership;
 import com.sn.onepay.entity.QSubvention;
 import com.sn.onepay.entity.Subvention;
 import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.mapper.SubventionMapper;
+import com.sn.onepay.repository.EmployeeGroupRepository;
+import com.sn.onepay.repository.PartnershipRepository;
 import com.sn.onepay.repository.SubventionRepository;
 import com.sn.onepay.services.SubventionService;
 import jakarta.transaction.Transactional;
@@ -29,21 +35,40 @@ import java.util.UUID;
 public class SubventionServiceImpl implements SubventionService {
 
     final SubventionRepository subventionRepository;
+    final PartnershipRepository partnershipRepository;
+    final EmployeeGroupRepository employeeGroupRepository;
     final SubventionMapper subventionMapper;
 
     @Override
-    public SubventionDTO createSubvention(SubventionDTO subventionDTO) {
+    public SubventionDTO createSubvention(SubventionCreateDTO subventionCreateDTO) {
 
-        if (Math.abs(subventionDTO.employeePercent() + subventionDTO.employerPercent() - 100.0) > 0.001) {
-            throw new ObjectValidationException("La somme des pourcentages employé et employeur doit être égale à 100");
-        }
+        validatePercentages(subventionCreateDTO.employeePercent(), subventionCreateDTO.employerPercent());
 
-        if (subventionDTO.partnership() == null || !Boolean.TRUE.equals(subventionDTO.partnership().active())) {
+        Partnership partnership = partnershipRepository.findById(subventionCreateDTO.partnershipId())
+                .orElseThrow(() -> new ResourceNotFoundException("Partnership", "ID", subventionCreateDTO.partnershipId()));
+
+        if (!partnership.isActive()) {
             throw new ObjectValidationException("Un partenariat actif est requis pour créer une subvention");
         }
 
-        Subvention subvention = subventionMapper.asEntity(subventionDTO);
+        EmployeeGroup employeeGroup = employeeGroupRepository.findById(subventionCreateDTO.employeeGroupId())
+                .orElseThrow(() -> new ResourceNotFoundException("EmployeeGroup", "ID", subventionCreateDTO.employeeGroupId()));
+
+        if (!employeeGroup.isActive()) {
+            throw new ObjectValidationException("Un groupe de collaborateurs actif est requis pour créer une subvention");
+        }
+
+        if (employeeGroup.getEnterprise() == null || partnership.getEnterprise() == null
+                || !employeeGroup.getEnterprise().getId().equals(partnership.getEnterprise().getId())) {
+            throw new ObjectValidationException("Le groupe de collaborateurs doit appartenir à l'entreprise du partenariat");
+        }
+
+        Subvention subvention = new Subvention();
         subvention.setRef(UUID.randomUUID().toString());
+        subvention.setEmployeePercent(subventionCreateDTO.employeePercent());
+        subvention.setEmployerPercent(subventionCreateDTO.employerPercent());
+        subvention.setPartnership(partnership);
+        subvention.setEmployeeGroup(employeeGroup);
         subvention.setActive(true);
         var savedSubvention = subventionRepository.save(subvention);
 
@@ -54,14 +79,17 @@ public class SubventionServiceImpl implements SubventionService {
     }
 
     @Override
-    public SubventionDTO updateSubvention(SubventionDTO subventionDTO, Long subventionId) {
+    public SubventionDTO updateSubvention(SubventionUpdateDTO subventionUpdateDTO, Long subventionId) {
 
         Subvention existing = subventionRepository.findById(subventionId)
                 .orElseThrow(() -> new ResourceNotFoundException("Subvention", "ID", subventionId));
 
-        if (subventionDTO.employeePercent() != null) existing.setEmployeePercent(subventionDTO.employeePercent());
-        if (subventionDTO.employerPercent() != null) existing.setEmployerPercent(subventionDTO.employerPercent());
-        if (subventionDTO.active() != null) existing.setActive(subventionDTO.active());
+        if (subventionUpdateDTO.employeePercent() != null || subventionUpdateDTO.employerPercent() != null) {
+            validatePercentages(subventionUpdateDTO.employeePercent(), subventionUpdateDTO.employerPercent());
+            existing.setEmployeePercent(subventionUpdateDTO.employeePercent());
+            existing.setEmployerPercent(subventionUpdateDTO.employerPercent());
+        }
+        if (subventionUpdateDTO.active() != null) existing.setActive(subventionUpdateDTO.active());
 
         var updated = subventionRepository.saveAndFlush(existing);
 
@@ -118,5 +146,15 @@ public class SubventionServiceImpl implements SubventionService {
 
         Page<Subvention> result = subventionRepository.findAll(builder, pageable);
         return result.map(subventionMapper::asDTO);
+    }
+
+    private void validatePercentages(Double employeePercent, Double employerPercent) {
+
+        if (employeePercent == null || employerPercent == null) {
+            throw new ObjectValidationException("Les pourcentages employé et employeur doivent être fournis ensemble");
+        }
+        if (Math.abs(employeePercent + employerPercent - 100.0) > 0.001) {
+            throw new ObjectValidationException("La somme des pourcentages employé et employeur doit être égale à 100");
+        }
     }
 }

--- a/src/test/java/com/sn/onepay/controller/EmployeeGroupControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/EmployeeGroupControllerTest.java
@@ -38,8 +38,16 @@ class EmployeeGroupControllerTest extends BaseControllerTest {
 
         mockMvc.perform(post("/v1/onepay/employee-group")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"RH\",\"enterprise\":{\"id\":1,\"name\":\"Corp\",\"maxQuota\":100}}"))
+                        .content("{\"name\":\"RH\",\"enterpriseId\":1,\"clientIds\":[1,2]}"))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createEmployeeGroup_withMissingRequiredFields_returns400() throws Exception {
+        mockMvc.perform(post("/v1/onepay/employee-group")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"RH\"}"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -48,7 +56,7 @@ class EmployeeGroupControllerTest extends BaseControllerTest {
 
         mockMvc.perform(put("/v1/onepay/employee-group/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"RH Updated\",\"enterprise\":{\"id\":1,\"name\":\"Corp\",\"maxQuota\":100}}"))
+                        .content("{\"name\":\"RH Updated\",\"clientIds\":[3],\"active\":true}"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/sn/onepay/controller/SubventionControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/SubventionControllerTest.java
@@ -38,10 +38,16 @@ class SubventionControllerTest extends BaseControllerTest {
 
         mockMvc.perform(post("/v1/onepay/subvention")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"employeePercent\":60.0,\"employerPercent\":40.0," +
-                                "\"partnership\":{\"id\":1,\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"status\":\"ACTIVE\"}," +
-                                "\"employeeGroup\":{\"id\":1,\"name\":\"RH\",\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100}}}"))
+                        .content("{\"employeePercent\":60.0,\"employerPercent\":40.0,\"partnershipId\":1,\"employeeGroupId\":2}"))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createSubvention_withMissingRequiredFields_returns400() throws Exception {
+        mockMvc.perform(post("/v1/onepay/subvention")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeePercent\":60.0,\"employerPercent\":40.0}"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -50,9 +56,7 @@ class SubventionControllerTest extends BaseControllerTest {
 
         mockMvc.perform(put("/v1/onepay/subvention/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"employeePercent\":60.0,\"employerPercent\":40.0," +
-                                "\"partnership\":{\"id\":1,\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100},\"status\":\"ACTIVE\"}," +
-                                "\"employeeGroup\":{\"id\":1,\"name\":\"RH\",\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100}}}"))
+                        .content("{\"employeePercent\":70.0,\"employerPercent\":30.0,\"active\":true}"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/sn/onepay/services/impl/EmployeeGroupServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/EmployeeGroupServiceImplTest.java
@@ -1,10 +1,17 @@
 package com.sn.onepay.services.impl;
 
+import com.sn.onepay.dto.EmployeeGroupCreateDTO;
 import com.sn.onepay.dto.EmployeeGroupDTO;
+import com.sn.onepay.dto.EmployeeGroupUpdateDTO;
+import com.sn.onepay.entity.Client;
 import com.sn.onepay.entity.EmployeeGroup;
+import com.sn.onepay.entity.Enterprise;
+import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.mapper.EmployeeGroupMapper;
+import com.sn.onepay.repository.ClientRepository;
 import com.sn.onepay.repository.EmployeeGroupRepository;
+import com.sn.onepay.repository.EnterpriseRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,7 +28,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EmployeeGroupServiceImplTest {
@@ -30,67 +39,174 @@ class EmployeeGroupServiceImplTest {
     EmployeeGroupRepository employeeGroupRepository;
 
     @Mock
+    EnterpriseRepository enterpriseRepository;
+
+    @Mock
+    ClientRepository clientRepository;
+
+    @Mock
     EmployeeGroupMapper employeeGroupMapper;
 
     @InjectMocks
     EmployeeGroupServiceImpl employeeGroupService;
 
+    private Enterprise enterprise(Long id) {
+        var enterprise = new Enterprise();
+        enterprise.setId(id);
+        return enterprise;
+    }
+
+    private Client client(boolean active, Enterprise enterprise) {
+        var client = new Client();
+        client.setActive(active);
+        client.setEnterprise(enterprise);
+        return client;
+    }
+
     @Test
-    void createEmployeeGroup_savesAndReturnsDTO() {
-        var dto = mock(EmployeeGroupDTO.class);
-        var entity = new EmployeeGroup();
+    void createEmployeeGroup_throwsWhenEnterpriseNotFound() {
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.empty());
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, null);
+
+        assertThatThrownBy(() -> employeeGroupService.createEmployeeGroup(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Enterprise");
+    }
+
+    @Test
+    void createEmployeeGroup_throwsWhenClientNotFound() {
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise(1L)));
+        when(clientRepository.findById(5L)).thenReturn(Optional.empty());
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, List.of(5L));
+
+        assertThatThrownBy(() -> employeeGroupService.createEmployeeGroup(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Client");
+    }
+
+    @Test
+    void createEmployeeGroup_throwsWhenClientNotActive() {
+        var enterprise = enterprise(1L);
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client(false, enterprise)));
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, List.of(5L));
+
+        assertThatThrownBy(() -> employeeGroupService.createEmployeeGroup(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("inactif");
+    }
+
+    @Test
+    void createEmployeeGroup_throwsWhenClientHasNoEnterprise() {
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise(1L)));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client(true, null)));
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, List.of(5L));
+
+        assertThatThrownBy(() -> employeeGroupService.createEmployeeGroup(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("n'appartient pas");
+    }
+
+    @Test
+    void createEmployeeGroup_throwsWhenClientBelongsToAnotherEnterprise() {
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise(1L)));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client(true, enterprise(2L))));
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, List.of(5L));
+
+        assertThatThrownBy(() -> employeeGroupService.createEmployeeGroup(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("n'appartient pas");
+    }
+
+    @Test
+    void createEmployeeGroup_withoutClients_savesAndReturnsDTO() {
+        var enterprise = enterprise(1L);
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise));
+
         var saved = new EmployeeGroup();
         var resultDTO = mock(EmployeeGroupDTO.class);
-
-        when(employeeGroupMapper.asEntity(dto)).thenReturn(entity);
-        when(employeeGroupRepository.save(any(EmployeeGroup.class))).thenReturn(saved);
+        when(employeeGroupRepository.save(any(EmployeeGroup.class))).thenAnswer(invocation -> {
+            EmployeeGroup toSave = invocation.getArgument(0);
+            assertThat(toSave.getRef()).isNotNull();
+            assertThat(toSave.getName()).isEqualTo("RH");
+            assertThat(toSave.getEnterprise()).isEqualTo(enterprise);
+            assertThat(toSave.getClients()).isNull();
+            assertThat(toSave.isActive()).isTrue();
+            return saved;
+        });
         when(employeeGroupMapper.asDTO(saved)).thenReturn(resultDTO);
 
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, null);
         var result = employeeGroupService.createEmployeeGroup(dto);
 
         assertThat(result).isEqualTo(resultDTO);
-        assertThat(entity.isActive()).isTrue();
-        assertThat(entity.getRef()).isNotNull();
+    }
+
+    @Test
+    void createEmployeeGroup_withClients_savesAndReturnsDTO() {
+        var enterprise = enterprise(1L);
+        var client = client(true, enterprise);
+        when(enterpriseRepository.findById(1L)).thenReturn(Optional.of(enterprise));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client));
+
+        var saved = new EmployeeGroup();
+        var resultDTO = mock(EmployeeGroupDTO.class);
+        when(employeeGroupRepository.save(any(EmployeeGroup.class))).thenAnswer(invocation -> {
+            EmployeeGroup toSave = invocation.getArgument(0);
+            assertThat(toSave.getClients()).containsExactly(client);
+            return saved;
+        });
+        when(employeeGroupMapper.asDTO(saved)).thenReturn(resultDTO);
+
+        var dto = new EmployeeGroupCreateDTO("RH", 1L, List.of(5L));
+        var result = employeeGroupService.createEmployeeGroup(dto);
+
+        assertThat(result).isEqualTo(resultDTO);
     }
 
     @Test
     void updateEmployeeGroup_throwsWhenNotFound() {
         when(employeeGroupRepository.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> employeeGroupService.updateEmployeeGroup(mock(EmployeeGroupDTO.class), 99L))
+        var dto = new EmployeeGroupUpdateDTO(null, null, null);
+
+        assertThatThrownBy(() -> employeeGroupService.updateEmployeeGroup(dto, 99L))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test
     void updateEmployeeGroup_modifiesFieldsAndSaves() {
-        var dto = mock(EmployeeGroupDTO.class);
-        when(dto.name()).thenReturn("New Name");
-        when(dto.active()).thenReturn(false);
-
+        var enterprise = enterprise(1L);
+        var client = client(true, enterprise);
         var existing = new EmployeeGroup();
         existing.setName("Old Name");
+        existing.setEnterprise(enterprise);
         existing.setActive(true);
 
         var updated = new EmployeeGroup();
         var resultDTO = mock(EmployeeGroupDTO.class);
 
         when(employeeGroupRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client));
         when(employeeGroupRepository.saveAndFlush(existing)).thenReturn(updated);
         when(employeeGroupMapper.asDTO(updated)).thenReturn(resultDTO);
 
+        var dto = new EmployeeGroupUpdateDTO("New Name", List.of(5L), false);
         var result = employeeGroupService.updateEmployeeGroup(dto, 1L);
 
         assertThat(existing.getName()).isEqualTo("New Name");
+        assertThat(existing.getClients()).containsExactly(client);
         assertThat(existing.isActive()).isFalse();
         assertThat(result).isEqualTo(resultDTO);
     }
 
     @Test
-    void updateEmployeeGroup_withNullActive_doesNotChangeActive() {
-        var dto = mock(EmployeeGroupDTO.class);
-        when(dto.name()).thenReturn("Updated Name");
-        when(dto.active()).thenReturn(null);
-
+    void updateEmployeeGroup_withNullFields_doesNotChangeFields() {
         var existing = new EmployeeGroup();
         existing.setName("Old Name");
         existing.setActive(true);
@@ -102,9 +218,27 @@ class EmployeeGroupServiceImplTest {
         when(employeeGroupRepository.saveAndFlush(existing)).thenReturn(updated);
         when(employeeGroupMapper.asDTO(updated)).thenReturn(resultDTO);
 
+        var dto = new EmployeeGroupUpdateDTO(null, null, null);
         employeeGroupService.updateEmployeeGroup(dto, 1L);
 
+        assertThat(existing.getName()).isEqualTo("Old Name");
+        assertThat(existing.getClients()).isNull();
         assertThat(existing.isActive()).isTrue();
+    }
+
+    @Test
+    void updateEmployeeGroup_throwsWhenGroupHasNoEnterpriseAndClientsProvided() {
+        var existing = new EmployeeGroup();
+        existing.setEnterprise(null);
+
+        when(employeeGroupRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(clientRepository.findById(5L)).thenReturn(Optional.of(client(true, enterprise(1L))));
+
+        var dto = new EmployeeGroupUpdateDTO(null, List.of(5L), null);
+
+        assertThatThrownBy(() -> employeeGroupService.updateEmployeeGroup(dto, 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("n'appartient pas");
     }
 
     @Test
@@ -136,6 +270,19 @@ class EmployeeGroupServiceImplTest {
 
         Page<EmployeeGroupDTO> result = employeeGroupService.getEmployeeGroupsByFilters(
                 null, null, null, null, null, null, null, Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getEmployeeGroupsByFilters_withEmptyRefAndName_ignoresThoseFilters() {
+        var page = new PageImpl<>(List.of(new EmployeeGroup()));
+        when(employeeGroupRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(employeeGroupMapper.asDTO(any(EmployeeGroup.class))).thenReturn(mock(EmployeeGroupDTO.class));
+
+        Page<EmployeeGroupDTO> result = employeeGroupService.getEmployeeGroupsByFilters(
+                null, "", "", null, null, null, null, Pageable.unpaged());
 
         assertThat(result).hasSize(1);
     }

--- a/src/test/java/com/sn/onepay/services/impl/SubventionServiceImplTest.java
+++ b/src/test/java/com/sn/onepay/services/impl/SubventionServiceImplTest.java
@@ -1,11 +1,17 @@
 package com.sn.onepay.services.impl;
 
-import com.sn.onepay.dto.PartnershipDTO;
+import com.sn.onepay.dto.SubventionCreateDTO;
 import com.sn.onepay.dto.SubventionDTO;
+import com.sn.onepay.dto.SubventionUpdateDTO;
+import com.sn.onepay.entity.EmployeeGroup;
+import com.sn.onepay.entity.Enterprise;
+import com.sn.onepay.entity.Partnership;
 import com.sn.onepay.entity.Subvention;
 import com.sn.onepay.exceptions.ObjectValidationException;
 import com.sn.onepay.exceptions.ResourceNotFoundException;
 import com.sn.onepay.mapper.SubventionMapper;
+import com.sn.onepay.repository.EmployeeGroupRepository;
+import com.sn.onepay.repository.PartnershipRepository;
 import com.sn.onepay.repository.SubventionRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +29,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SubventionServiceImplTest {
@@ -32,24 +40,58 @@ class SubventionServiceImplTest {
     SubventionRepository subventionRepository;
 
     @Mock
+    PartnershipRepository partnershipRepository;
+
+    @Mock
+    EmployeeGroupRepository employeeGroupRepository;
+
+    @Mock
     SubventionMapper subventionMapper;
 
     @InjectMocks
     SubventionServiceImpl subventionService;
 
-    private SubventionDTO buildDTO(Double emp, Double employer, PartnershipDTO partnership) {
-        var dto = mock(SubventionDTO.class);
-        when(dto.employeePercent()).thenReturn(emp);
-        when(dto.employerPercent()).thenReturn(employer);
-        when(dto.partnership()).thenReturn(partnership);
-        return dto;
+    private Enterprise enterprise(Long id) {
+        var enterprise = new Enterprise();
+        enterprise.setId(id);
+        return enterprise;
+    }
+
+    private Partnership partnership(boolean active, Enterprise enterprise) {
+        var partnership = new Partnership();
+        partnership.setActive(active);
+        partnership.setEnterprise(enterprise);
+        return partnership;
+    }
+
+    private EmployeeGroup employeeGroup(boolean active, Enterprise enterprise) {
+        var group = new EmployeeGroup();
+        group.setActive(active);
+        group.setEnterprise(enterprise);
+        return group;
+    }
+
+    @Test
+    void createSubvention_throwsWhenEmployeePercentIsNull() {
+        var dto = new SubventionCreateDTO(null, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("ensemble");
+    }
+
+    @Test
+    void createSubvention_throwsWhenEmployerPercentIsNull() {
+        var dto = new SubventionCreateDTO(60.0, null, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("ensemble");
     }
 
     @Test
     void createSubvention_throwsWhenPercentagesNotEqualTo100() {
-        var dto = mock(SubventionDTO.class);
-        when(dto.employeePercent()).thenReturn(40.0);
-        when(dto.employerPercent()).thenReturn(40.0);
+        var dto = new SubventionCreateDTO(40.0, 40.0, 1L, 2L);
 
         assertThatThrownBy(() -> subventionService.createSubvention(dto))
                 .isInstanceOf(ObjectValidationException.class)
@@ -57,20 +99,21 @@ class SubventionServiceImplTest {
     }
 
     @Test
-    void createSubvention_throwsWhenPartnershipIsNull() {
-        var dto = buildDTO(60.0, 40.0, null);
+    void createSubvention_throwsWhenPartnershipNotFound() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.empty());
+
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
 
         assertThatThrownBy(() -> subventionService.createSubvention(dto))
-                .isInstanceOf(ObjectValidationException.class)
-                .hasMessageContaining("partenariat");
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Partnership");
     }
 
     @Test
     void createSubvention_throwsWhenPartnershipNotActive() {
-        var partnership = mock(PartnershipDTO.class);
-        when(partnership.active()).thenReturn(false);
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(false, enterprise(10L))));
 
-        var dto = buildDTO(60.0, 40.0, partnership);
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
 
         assertThatThrownBy(() -> subventionService.createSubvention(dto))
                 .isInstanceOf(ObjectValidationException.class)
@@ -78,41 +121,137 @@ class SubventionServiceImplTest {
     }
 
     @Test
-    void createSubvention_happyPath() {
-        var partnership = mock(PartnershipDTO.class);
-        when(partnership.active()).thenReturn(true);
+    void createSubvention_throwsWhenEmployeeGroupNotFound() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(true, enterprise(10L))));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.empty());
 
-        var dto = buildDTO(60.0, 40.0, partnership);
-        var entity = new Subvention();
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("EmployeeGroup");
+    }
+
+    @Test
+    void createSubvention_throwsWhenEmployeeGroupNotActive() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(true, enterprise(10L))));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.of(employeeGroup(false, enterprise(10L))));
+
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("groupe de collaborateurs actif");
+    }
+
+    @Test
+    void createSubvention_throwsWhenEmployeeGroupHasNoEnterprise() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(true, enterprise(10L))));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.of(employeeGroup(true, null)));
+
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("entreprise du partenariat");
+    }
+
+    @Test
+    void createSubvention_throwsWhenPartnershipHasNoEnterprise() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(true, null)));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.of(employeeGroup(true, enterprise(10L))));
+
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("entreprise du partenariat");
+    }
+
+    @Test
+    void createSubvention_throwsWhenEnterprisesDoNotMatch() {
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership(true, enterprise(10L))));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.of(employeeGroup(true, enterprise(20L))));
+
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
+
+        assertThatThrownBy(() -> subventionService.createSubvention(dto))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("entreprise du partenariat");
+    }
+
+    @Test
+    void createSubvention_happyPath() {
+        var partnership = partnership(true, enterprise(10L));
+        var group = employeeGroup(true, enterprise(10L));
+        when(partnershipRepository.findById(1L)).thenReturn(Optional.of(partnership));
+        when(employeeGroupRepository.findById(2L)).thenReturn(Optional.of(group));
+
         var saved = new Subvention();
         var resultDTO = mock(SubventionDTO.class);
-
-        when(subventionMapper.asEntity(dto)).thenReturn(entity);
-        when(subventionRepository.save(any(Subvention.class))).thenReturn(saved);
+        when(subventionRepository.save(any(Subvention.class))).thenAnswer(invocation -> {
+            Subvention toSave = invocation.getArgument(0);
+            assertThat(toSave.getRef()).isNotNull();
+            assertThat(toSave.getEmployeePercent()).isEqualTo(60.0);
+            assertThat(toSave.getEmployerPercent()).isEqualTo(40.0);
+            assertThat(toSave.getPartnership()).isEqualTo(partnership);
+            assertThat(toSave.getEmployeeGroup()).isEqualTo(group);
+            assertThat(toSave.isActive()).isTrue();
+            return saved;
+        });
         when(subventionMapper.asDTO(saved)).thenReturn(resultDTO);
 
+        var dto = new SubventionCreateDTO(60.0, 40.0, 1L, 2L);
         var result = subventionService.createSubvention(dto);
 
         assertThat(result).isEqualTo(resultDTO);
-        assertThat(entity.isActive()).isTrue();
-        assertThat(entity.getRef()).isNotNull();
     }
 
     @Test
     void updateSubvention_throwsWhenNotFound() {
         when(subventionRepository.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> subventionService.updateSubvention(mock(SubventionDTO.class), 99L))
+        var dto = new SubventionUpdateDTO(null, null, null);
+
+        assertThatThrownBy(() -> subventionService.updateSubvention(dto, 99L))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test
-    void updateSubvention_modifiesFieldsAndSaves() {
-        var dto = mock(SubventionDTO.class);
-        when(dto.employeePercent()).thenReturn(70.0);
-        when(dto.employerPercent()).thenReturn(30.0);
-        when(dto.active()).thenReturn(false);
+    void updateSubvention_throwsWhenOnlyEmployeePercentProvided() {
+        when(subventionRepository.findById(1L)).thenReturn(Optional.of(new Subvention()));
 
+        var dto = new SubventionUpdateDTO(60.0, null, null);
+
+        assertThatThrownBy(() -> subventionService.updateSubvention(dto, 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("ensemble");
+    }
+
+    @Test
+    void updateSubvention_throwsWhenOnlyEmployerPercentProvided() {
+        when(subventionRepository.findById(1L)).thenReturn(Optional.of(new Subvention()));
+
+        var dto = new SubventionUpdateDTO(null, 40.0, null);
+
+        assertThatThrownBy(() -> subventionService.updateSubvention(dto, 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("ensemble");
+    }
+
+    @Test
+    void updateSubvention_throwsWhenPercentagesNotEqualTo100() {
+        when(subventionRepository.findById(1L)).thenReturn(Optional.of(new Subvention()));
+
+        var dto = new SubventionUpdateDTO(70.0, 40.0, null);
+
+        assertThatThrownBy(() -> subventionService.updateSubvention(dto, 1L))
+                .isInstanceOf(ObjectValidationException.class)
+                .hasMessageContaining("100");
+    }
+
+    @Test
+    void updateSubvention_modifiesFieldsAndSaves() {
         var existing = new Subvention();
         existing.setActive(true);
         var updated = new Subvention();
@@ -122,6 +261,7 @@ class SubventionServiceImplTest {
         when(subventionRepository.saveAndFlush(existing)).thenReturn(updated);
         when(subventionMapper.asDTO(updated)).thenReturn(resultDTO);
 
+        var dto = new SubventionUpdateDTO(70.0, 30.0, false);
         var result = subventionService.updateSubvention(dto, 1L);
 
         assertThat(existing.getEmployeePercent()).isEqualTo(70.0);
@@ -132,11 +272,6 @@ class SubventionServiceImplTest {
 
     @Test
     void updateSubvention_withNullFields_doesNotChangeFields() {
-        var dto = mock(SubventionDTO.class);
-        when(dto.employeePercent()).thenReturn(null);
-        when(dto.employerPercent()).thenReturn(null);
-        when(dto.active()).thenReturn(null);
-
         var existing = new Subvention();
         existing.setEmployeePercent(60.0);
         existing.setEmployerPercent(40.0);
@@ -149,6 +284,7 @@ class SubventionServiceImplTest {
         when(subventionRepository.saveAndFlush(existing)).thenReturn(updated);
         when(subventionMapper.asDTO(updated)).thenReturn(resultDTO);
 
+        var dto = new SubventionUpdateDTO(null, null, null);
         subventionService.updateSubvention(dto, 1L);
 
         assertThat(existing.getEmployeePercent()).isEqualTo(60.0);
@@ -185,6 +321,19 @@ class SubventionServiceImplTest {
 
         Page<SubventionDTO> result = subventionService.getSubventionsByFilters(
                 null, null, null, null, null, null, null, null, null, Pageable.unpaged());
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void getSubventionsByFilters_withEmptyRef_ignoresRefFilter() {
+        var page = new PageImpl<>(List.of(new Subvention()));
+        when(subventionRepository.findAll(any(com.querydsl.core.types.Predicate.class), any(Pageable.class)))
+                .thenReturn(page);
+        when(subventionMapper.asDTO(any(Subvention.class))).thenReturn(mock(SubventionDTO.class));
+
+        Page<SubventionDTO> result = subventionService.getSubventionsByFilters(
+                null, "", null, null, null, null, null, null, null, Pageable.unpaged());
 
         assertThat(result).hasSize(1);
     }


### PR DESCRIPTION
- SubventionCreateDTO (percents + partnershipId + employeeGroupId) et SubventionUpdateDTO (update partiel)
- EmployeeGroupCreateDTO (name + enterpriseId + clientIds) et EmployeeGroupUpdateDTO
- Validations serveur : partenariat/groupe actifs chargés en base, groupe lié à l'entreprise du partenariat, clients actifs appartenant à l'entreprise du groupe, somme des pourcentages = 100 aussi à l'update
- Tests : 218 tests, couverture 100% lignes/branches sur les deux services