### PR TITLE
feat: sécurisation de l'API par JWT Keycloak (resource server)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>
@@ -78,6 +88,12 @@
         <dependency>
             <groupId>org.springframework.batch</groupId>
             <artifactId>spring-batch-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/sn/onepay/security/KeycloakRealmRoleConverter.java
+++ b/src/main/java/com/sn/onepay/security/KeycloakRealmRoleConverter.java
@@ -1,0 +1,28 @@
+package com.sn.onepay.security;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class KeycloakRealmRoleConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Collection<GrantedAuthority> convert(Jwt jwt) {
+
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null || realmAccess.get("roles") == null) {
+            return List.of();
+        }
+
+        Collection<String> roles = (Collection<String>) realmAccess.get("roles");
+        return roles.stream()
+                .map(role -> (GrantedAuthority) new SimpleGrantedAuthority("ROLE_" + role))
+                .toList();
+    }
+}

--- a/src/main/java/com/sn/onepay/security/SecurityConfig.java
+++ b/src/main/java/com/sn/onepay/security/SecurityConfig.java
@@ -1,0 +1,74 @@
+package com.sn.onepay.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    static final String SUPER_ADMIN = "SUPER_ADMIN";
+    static final String ENTERPRISE_ADMIN = "ENTERPRISE_ADMIN";
+    static final String ENTERPRISE_FINANCE = "ENTERPRISE_FINANCE";
+    static final String SALES_ADMIN = "SALES_ADMIN";
+    static final String SALES_FINANCE = "SALES_FINANCE";
+    static final String CLIENT = "CLIENT";
+    static final String CASHIER = "CASHIER";
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
+
+                        // Plateforme : entreprises, commerces et partenariats gérés par le SUPER_ADMIN uniquement
+                        .requestMatchers(HttpMethod.POST, "/v1/onepay/enterprise/**", "/v1/onepay/sales/**", "/v1/onepay/partnership/**").hasRole(SUPER_ADMIN)
+                        .requestMatchers(HttpMethod.PUT, "/v1/onepay/enterprise/**", "/v1/onepay/sales/**", "/v1/onepay/partnership/**").hasRole(SUPER_ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/v1/onepay/enterprise/**", "/v1/onepay/sales/**", "/v1/onepay/partnership/**").hasRole(SUPER_ADMIN)
+
+                        // Côté entreprise : clients, profils, configurations, groupes et subventions
+                        .requestMatchers(HttpMethod.POST, "/v1/onepay/client/**", "/v1/onepay/enterprise-profile/**", "/v1/onepay/enterprise-configuration/**", "/v1/onepay/employee-group/**", "/v1/onepay/subvention/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_ADMIN)
+                        .requestMatchers(HttpMethod.PUT, "/v1/onepay/client/**", "/v1/onepay/enterprise-profile/**", "/v1/onepay/enterprise-configuration/**", "/v1/onepay/employee-group/**", "/v1/onepay/subvention/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/v1/onepay/client/**", "/v1/onepay/enterprise-profile/**", "/v1/onepay/enterprise-configuration/**", "/v1/onepay/employee-group/**", "/v1/onepay/subvention/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_ADMIN)
+
+                        // Côté commerce : caissiers, profils et configurations du point de vente
+                        .requestMatchers(HttpMethod.POST, "/v1/onepay/cashier/**", "/v1/onepay/sales-profile/**", "/v1/onepay/sales-configuration/**").hasAnyRole(SUPER_ADMIN, SALES_ADMIN)
+                        .requestMatchers(HttpMethod.PUT, "/v1/onepay/cashier/**", "/v1/onepay/sales-profile/**", "/v1/onepay/sales-configuration/**").hasAnyRole(SUPER_ADMIN, SALES_ADMIN)
+                        .requestMatchers(HttpMethod.DELETE, "/v1/onepay/cashier/**", "/v1/onepay/sales-profile/**", "/v1/onepay/sales-configuration/**").hasAnyRole(SUPER_ADMIN, SALES_ADMIN)
+
+                        // Paiements : créés par un employé ou un caissier, annulés (suppression logique) par le caissier
+                        .requestMatchers(HttpMethod.POST, "/v1/onepay/payment/**").hasAnyRole(CLIENT, CASHIER)
+                        .requestMatchers(HttpMethod.PUT, "/v1/onepay/payment/**").hasRole(CASHIER)
+                        .requestMatchers(HttpMethod.DELETE, "/v1/onepay/payment/**").hasRole(CASHIER)
+
+                        // Factures : gérées par la plateforme et validées par les rôles finance
+                        .requestMatchers(HttpMethod.POST, "/v1/onepay/bills/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_FINANCE, SALES_FINANCE)
+                        .requestMatchers(HttpMethod.PUT, "/v1/onepay/bills/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_FINANCE, SALES_FINANCE)
+                        .requestMatchers(HttpMethod.DELETE, "/v1/onepay/bills/**").hasAnyRole(SUPER_ADMIN, ENTERPRISE_FINANCE, SALES_FINANCE)
+
+                        // Lectures (GET) et QR codes : tout utilisateur authentifié
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new KeycloakRealmRoleConverter());
+        return converter;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
     change-log: classpath:db.changelog-master.xml
     enabled: true
 
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:8080/realms/onepay}
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/test/java/com/sn/onepay/controller/BaseControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/BaseControllerTest.java
@@ -2,9 +2,14 @@ package com.sn.onepay.controller;
 
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 
+/*Each subclass disables security filters via @AutoConfigureMockMvc(addFilters = false): authorization rules are covered by SecurityConfigTest*/
 abstract class BaseControllerTest {
 
     @MockBean
     JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockBean
+    JwtDecoder jwtDecoder;
 }

--- a/src/test/java/com/sn/onepay/controller/BillsControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/BillsControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.BillsDTO;
 import com.sn.onepay.services.BillsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BillsController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class BillsControllerTest extends BaseControllerTest {
 
     static final String VALID_BODY = "{\"partnership\":{\"id\":1,\"sales\":{\"id\":1,\"type\":\"RESTAURATION\"},\"enterprise\":{\"id\":2,\"name\":\"Corp\",\"maxQuota\":100}}," +

--- a/src/test/java/com/sn/onepay/controller/CashierControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/CashierControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.CashierDTO;
 import com.sn.onepay.services.CashierService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -21,6 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CashierController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class CashierControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/ClientControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/ClientControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.ClientDTO;
 import com.sn.onepay.services.ClientService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ClientController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class ClientControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/EmployeeGroupControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/EmployeeGroupControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.EmployeeGroupDTO;
 import com.sn.onepay.services.EmployeeGroupService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EmployeeGroupController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class EmployeeGroupControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/EnterpriseConfigurationControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/EnterpriseConfigurationControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.EnterpriseConfigurationDTO;
 import com.sn.onepay.services.EnterpriseConfigurationService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EnterpriseConfigurationController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class EnterpriseConfigurationControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/EnterpriseControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/EnterpriseControllerTest.java
@@ -6,6 +6,7 @@ import com.sn.onepay.repository.EnterpriseRepository;
 import com.sn.onepay.services.EnterpriseService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -26,6 +27,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EnterpriseController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class EnterpriseControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/EnterpriseProfileControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/EnterpriseProfileControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.EnterpriseProfileDTO;
 import com.sn.onepay.services.EnterpriseProfileService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(EnterpriseProfileController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class EnterpriseProfileControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/PartnershipControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/PartnershipControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.PartnershipDTO;
 import com.sn.onepay.services.PartnershipService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PartnershipController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class PartnershipControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/PaymentControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/PaymentControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.PaymentDTO;
 import com.sn.onepay.services.PaymentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PaymentController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class PaymentControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/QRCodeControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/QRCodeControllerTest.java
@@ -5,6 +5,7 @@ import com.sn.onepay.dto.QRCodeClientDTO;
 import com.sn.onepay.services.QRCodeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -15,6 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(QRCodeController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class QRCodeControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/SalesConfigurationsControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/SalesConfigurationsControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.SalesConfigurationsDTO;
 import com.sn.onepay.services.SalesConfigurationsService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SalesConfigurationsController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class SalesConfigurationsControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/SalesControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/SalesControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.SalesDTO;
 import com.sn.onepay.services.SalesService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SalesController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class SalesControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/SalesProfileControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/SalesProfileControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.SalesProfileDTO;
 import com.sn.onepay.services.SalesProfileService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SalesProfileController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class SalesProfileControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/controller/SubventionControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/SubventionControllerTest.java
@@ -4,6 +4,7 @@ import com.sn.onepay.dto.SubventionDTO;
 import com.sn.onepay.services.SubventionService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(SubventionController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class SubventionControllerTest extends BaseControllerTest {
 
     @Autowired

--- a/src/test/java/com/sn/onepay/security/KeycloakRealmRoleConverterTest.java
+++ b/src/test/java/com/sn/onepay/security/KeycloakRealmRoleConverterTest.java
@@ -1,0 +1,47 @@
+package com.sn.onepay.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeycloakRealmRoleConverterTest {
+
+    final KeycloakRealmRoleConverter converter = new KeycloakRealmRoleConverter();
+
+    private Jwt jwtWithClaim(String name, Object value) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim(name, value)
+                .build();
+    }
+
+    @Test
+    void convert_mapsRealmRolesToPrefixedAuthorities() {
+        var jwt = jwtWithClaim("realm_access", Map.of("roles", List.of("CLIENT", "CASHIER")));
+
+        var authorities = converter.convert(jwt);
+
+        assertThat(authorities)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("ROLE_CLIENT", "ROLE_CASHIER");
+    }
+
+    @Test
+    void convert_withoutRealmAccess_returnsNoAuthorities() {
+        var jwt = jwtWithClaim("sub", "user");
+
+        assertThat(converter.convert(jwt)).isEmpty();
+    }
+
+    @Test
+    void convert_withRealmAccessWithoutRoles_returnsNoAuthorities() {
+        var jwt = jwtWithClaim("realm_access", Map.of("other", "value"));
+
+        assertThat(converter.convert(jwt)).isEmpty();
+    }
+}

--- a/src/test/java/com/sn/onepay/security/SecurityConfigTest.java
+++ b/src/test/java/com/sn/onepay/security/SecurityConfigTest.java
@@ -1,0 +1,172 @@
+package com.sn.onepay.security;
+
+import com.sn.onepay.controller.PaymentController;
+import com.sn.onepay.dto.PaymentDTO;
+import com.sn.onepay.services.PaymentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PaymentController.class)
+@Import(SecurityConfig.class)
+class SecurityConfigTest {
+
+    static final String PAYMENT_BODY = "{\"client\":{\"id\":1},\"cashier\":{\"id\":2},\"amount\":50.0,\"status\":\"ACTIVE\",\"module\":\"RESTAURATION\"}";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PaymentService paymentService;
+
+    @MockBean
+    JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockBean
+    JwtDecoder jwtDecoder;
+
+    private static RequestPostProcessor as(String role) {
+        return jwt().authorities(new SimpleGrantedAuthority("ROLE_" + role));
+    }
+
+    /*Routes without a loaded controller pass security then return 404: any status except 401/403 proves access was granted*/
+    private static void assertAccessGranted(ResultActions actions) throws Exception {
+        int status = actions.andReturn().getResponse().getStatus();
+        assertThat(status).isNotIn(401, 403);
+    }
+
+    @Test
+    void anyRequest_withoutToken_returns401() throws Exception {
+        mockMvc.perform(get("/v1/onepay/payment"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void swagger_isAccessibleWithoutToken() throws Exception {
+        assertAccessGranted(mockMvc.perform(get("/v3/api-docs")));
+        assertAccessGranted(mockMvc.perform(get("/swagger-ui/index.html")));
+    }
+
+    @Test
+    void enterpriseWrites_requireSuperAdmin() throws Exception {
+        mockMvc.perform(post("/v1/onepay/enterprise").with(as("ENTERPRISE_ADMIN"))).andExpect(status().isForbidden());
+        mockMvc.perform(put("/v1/onepay/enterprise/1").with(as("CLIENT"))).andExpect(status().isForbidden());
+        mockMvc.perform(delete("/v1/onepay/enterprise/1").with(as("SALES_ADMIN"))).andExpect(status().isForbidden());
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/enterprise").with(as("SUPER_ADMIN"))));
+    }
+
+    @Test
+    void salesAndPartnershipWrites_requireSuperAdmin() throws Exception {
+        mockMvc.perform(post("/v1/onepay/sales").with(as("SALES_ADMIN"))).andExpect(status().isForbidden());
+        mockMvc.perform(delete("/v1/onepay/partnership/1").with(as("ENTERPRISE_ADMIN"))).andExpect(status().isForbidden());
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/sales").with(as("SUPER_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(delete("/v1/onepay/partnership/1").with(as("SUPER_ADMIN"))));
+    }
+
+    @Test
+    void enterpriseSideWrites_requireEnterpriseAdmin() throws Exception {
+        mockMvc.perform(post("/v1/onepay/client").with(as("CASHIER"))).andExpect(status().isForbidden());
+        mockMvc.perform(post("/v1/onepay/subvention").with(as("SALES_ADMIN"))).andExpect(status().isForbidden());
+        mockMvc.perform(put("/v1/onepay/employee-group/1").with(as("ENTERPRISE_FINANCE"))).andExpect(status().isForbidden());
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/client").with(as("ENTERPRISE_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/subvention").with(as("ENTERPRISE_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/enterprise-profile").with(as("ENTERPRISE_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(put("/v1/onepay/enterprise-configuration/1").with(as("SUPER_ADMIN"))));
+    }
+
+    @Test
+    void salesSideWrites_requireSalesAdmin() throws Exception {
+        mockMvc.perform(post("/v1/onepay/cashier").with(as("ENTERPRISE_ADMIN"))).andExpect(status().isForbidden());
+        mockMvc.perform(put("/v1/onepay/sales-configuration/1").with(as("CLIENT"))).andExpect(status().isForbidden());
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/cashier").with(as("SALES_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/sales-profile").with(as("SALES_ADMIN"))));
+        assertAccessGranted(mockMvc.perform(put("/v1/onepay/sales-configuration/1").with(as("SUPER_ADMIN"))));
+    }
+
+    @Test
+    void paymentCreation_isAllowedForClientAndCashier() throws Exception {
+        when(paymentService.createPayment(any())).thenReturn(mock(PaymentDTO.class));
+
+        mockMvc.perform(post("/v1/onepay/payment").with(as("ENTERPRISE_FINANCE"))
+                        .contentType(MediaType.APPLICATION_JSON).content(PAYMENT_BODY))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/v1/onepay/payment").with(as("CLIENT"))
+                        .contentType(MediaType.APPLICATION_JSON).content(PAYMENT_BODY))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/v1/onepay/payment").with(as("CASHIER"))
+                        .contentType(MediaType.APPLICATION_JSON).content(PAYMENT_BODY))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void paymentUpdateAndCancellation_requireCashier() throws Exception {
+        when(paymentService.updatePayment(any(), anyLong())).thenReturn(mock(PaymentDTO.class));
+        doNothing().when(paymentService).deletePayment(anyLong());
+
+        mockMvc.perform(delete("/v1/onepay/payment/1").with(as("CLIENT"))).andExpect(status().isForbidden());
+        mockMvc.perform(put("/v1/onepay/payment/1").with(as("CLIENT"))
+                        .contentType(MediaType.APPLICATION_JSON).content(PAYMENT_BODY))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/v1/onepay/payment/1").with(as("CASHIER"))).andExpect(status().isOk());
+        mockMvc.perform(put("/v1/onepay/payment/1").with(as("CASHIER"))
+                        .contentType(MediaType.APPLICATION_JSON).content(PAYMENT_BODY))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void billsWrites_requireFinanceOrSuperAdminRoles() throws Exception {
+        mockMvc.perform(post("/v1/onepay/bills").with(as("CLIENT"))).andExpect(status().isForbidden());
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/bills").with(as("ENTERPRISE_FINANCE"))));
+        assertAccessGranted(mockMvc.perform(post("/v1/onepay/bills").with(as("SALES_FINANCE"))));
+        assertAccessGranted(mockMvc.perform(put("/v1/onepay/bills/1").with(as("SUPER_ADMIN"))));
+    }
+
+    @Test
+    void reads_areAllowedForAnyAuthenticatedRole() throws Exception {
+        when(paymentService.getPaymentByFilters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/v1/onepay/payment").with(as("ENTERPRISE_FINANCE"))).andExpect(status().isOk());
+        assertAccessGranted(mockMvc.perform(get("/v1/onepay/enterprise").with(as("CASHIER"))));
+    }
+
+    @Test
+    void realmRolesFromJwtClaims_grantAccessThroughConverter() throws Exception {
+        doNothing().when(paymentService).deletePayment(anyLong());
+
+        mockMvc.perform(delete("/v1/onepay/payment/1")
+                        .with(jwt()
+                                .jwt(builder -> builder.claim("realm_access", Map.of("roles", List.of("CASHIER"))))
+                                .authorities(new KeycloakRealmRoleConverter())))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
- spring-boot-starter-security + oauth2-resource-server, issuer realm onepay (KEYCLOAK_ISSUER_URI surchargeable)
- KeycloakRealmRoleConverter : rôles realm du claim realm_access -> autorités ROLE_*
- SecurityConfig : API stateless fermée par défaut, matrice d'autorisations par rôle et par méthode HTTP selon les responsabilités métier, Swagger public en dev
- Tests : SecurityConfigTest (matrice 401/403/accès par rôle) + KeycloakRealmRoleConverterTest, controllers en addFilters=false
- 232 tests, 0 failures ; couverture 100% sur SecurityConfig et KeycloakRealmRoleConverter