### PR TITLE
feat: expose la somme des paiements par module (GET /payment/sum/{cli…

### DIFF
--- a/src/main/java/com/sn/onepay/controller/PaymentController.java
+++ b/src/main/java/com/sn/onepay/controller/PaymentController.java
@@ -85,7 +85,7 @@ public class PaymentController {
         return paymentService.getPaymentByFilters(id, ref, clientId, cashierId, amount, active, module, paymentDate, creationDate, modificationDate, pageable);
     }
 
-    @Operation(summary = "Get total consumed amount for a client", description = "Returns the sum of all active payments for a given client")
+    @Operation(summary = "Get total consumed amount for a client", description = "Returns the sum of all active payments for a given client, optionally restricted to a module")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Success"),
             @ApiResponse(responseCode = "404", description = "Client not found"),
@@ -93,8 +93,11 @@ public class PaymentController {
     })
     @GetMapping("/sum/{clientId}")
     @ResponseStatus(HttpStatus.OK)
-    public double getSumOfPaymentsByClient(@Parameter(description = "Client id", required = true) @PathVariable(name = "clientId") Long clientId) {
-        return paymentService.getSumOfAllPaymentsByClientId(clientId);
+    public double getSumOfPaymentsByClient(@Parameter(description = "Client id", required = true) @PathVariable(name = "clientId") Long clientId,
+                                           @Parameter(description = "Restrict the sum to a single module") @RequestParam(required = false) Modules module) {
+        return module == null
+                ? paymentService.getSumOfAllPaymentsByClientId(clientId)
+                : paymentService.getSumOfAllPaymentsByClientIdAndModule(clientId, module);
     }
 
     @Operation(summary = "Delete a payment by id", description = "This endpoint is for deleting payment by id")

--- a/src/test/java/com/sn/onepay/controller/PaymentControllerTest.java
+++ b/src/test/java/com/sn/onepay/controller/PaymentControllerTest.java
@@ -1,6 +1,7 @@
 package com.sn.onepay.controller;
 
 import com.sn.onepay.dto.PaymentDTO;
+import com.sn.onepay.enumeration.Modules;
 import com.sn.onepay.services.PaymentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,11 +18,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PaymentController.class)
@@ -68,7 +72,21 @@ class PaymentControllerTest extends BaseControllerTest {
         when(paymentService.getSumOfAllPaymentsByClientId(anyLong())).thenReturn(150.0);
 
         mockMvc.perform(get("/v1/onepay/payment/sum/1"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(content().string("150.0"));
+
+        verify(paymentService, never()).getSumOfAllPaymentsByClientIdAndModule(anyLong(), any());
+    }
+
+    @Test
+    void getSumOfPaymentsByClient_withModule_returns200() throws Exception {
+        when(paymentService.getSumOfAllPaymentsByClientIdAndModule(1L, Modules.MARKET)).thenReturn(80.0);
+
+        mockMvc.perform(get("/v1/onepay/payment/sum/1").param("module", "MARKET"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("80.0"));
+
+        verify(paymentService, never()).getSumOfAllPaymentsByClientId(anyLong());
     }
 
     @Test


### PR DESCRIPTION
…entId}?module=)

Le service getSumOfAllPaymentsByClientIdAndModule existait sans être exposé. Paramètre optionnel rétrocompatible — requis par l'accueil mobile (jauges de consommation par module).